### PR TITLE
Add InfoButtonWithToolTip to design system input components

### DIFF
--- a/@stellar/design-system/src/components/InfoButtonWithTooltip/index.tsx
+++ b/@stellar/design-system/src/components/InfoButtonWithTooltip/index.tsx
@@ -1,0 +1,59 @@
+import React, { useState, useEffect, useRef } from "react";
+import { Icon } from "@stellar/design-system";
+import "./styles.scss";
+
+export const InfoButtonWithTooltip = ({
+  children,
+}: {
+  children: string | React.ReactNode;
+}) => {
+  const toggleEl = useRef<null | HTMLDivElement>(null);
+  const infoEl = useRef<null | HTMLDivElement>(null);
+  const [isInfoVisible, setIsInfoVisible] = useState(false);
+
+  useEffect(() => {
+    if (isInfoVisible) {
+      document.addEventListener("mousedown", handleClickOutside);
+    } else {
+      document.removeEventListener("mousedown", handleClickOutside);
+    }
+
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [isInfoVisible]);
+
+  const handleClickOutside = (event: MouseEvent) => {
+    // Do nothing if clicking tooltip itself or link inside the tooltip
+    if (
+      event.target === infoEl?.current ||
+      infoEl?.current?.contains(event.target as Node)
+    ) {
+      return;
+    }
+
+    if (!toggleEl?.current?.contains(event.target as Node)) {
+      setIsInfoVisible(false);
+    }
+  };
+
+  return (
+    <>
+      <div
+        className="InfoButton"
+        ref={toggleEl}
+        onClick={() => setIsInfoVisible((currentState) => !currentState)}
+      >
+        <Icon.Info />
+      </div>
+
+      <div
+        className="InfoButtonTooltip"
+        ref={infoEl}
+        data-hidden={!isInfoVisible}
+      >
+        {children}
+      </div>
+    </>
+  );
+};

--- a/@stellar/design-system/src/components/InfoButtonWithTooltip/styles.scss
+++ b/@stellar/design-system/src/components/InfoButtonWithTooltip/styles.scss
@@ -1,0 +1,43 @@
+.InfoButton {
+  cursor: pointer;
+  width: 1.25rem;
+  height: 1.25rem;
+  margin-left: 0.3rem;
+  flex-shrink: 0;
+  position: relative;
+
+  svg {
+    width: 100%;
+    height: 100%;
+    // TODO: add info icon color to SDS
+    fill: #ccc;
+    position: absolute;
+    top: 0;
+    left: 0;
+  }
+}
+
+.InfoButtonTooltip {
+  position: absolute;
+  top: 2.2rem;
+  right: -0.5rem;
+  width: 270px;
+  border-radius: 0.25rem;
+  background-color: var(--color-accent);
+  padding: 1rem 1.5rem;
+  color: var(--color-text-contrast);
+  font-size: 0.875rem;
+  line-height: 1.5rem;
+  z-index: var(--z-index-tooltip);
+  cursor: default;
+  visibility: hidden;
+
+  &[data-hidden="false"] {
+    visibility: visible;
+  }
+
+  a {
+    color: inherit;
+    white-space: nowrap;
+  }
+}

--- a/@stellar/design-system/src/components/Input/index.tsx
+++ b/@stellar/design-system/src/components/Input/index.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { InfoButtonWithTooltip } from "../InfoButtonWithTooltip";
 import { FieldElement } from "../utils/FieldElement";
 import { FieldNote } from "../utils/FieldNote";
 import "./styles.scss";
@@ -10,6 +11,7 @@ interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
   rightElement?: string | React.ReactNode;
   note?: string | React.ReactNode;
   error?: string | React.ReactNode;
+  tooltipText?: string | React.ReactNode;
 }
 
 export const Input: React.FC<InputProps> = ({
@@ -19,6 +21,7 @@ export const Input: React.FC<InputProps> = ({
   rightElement,
   note,
   error,
+  tooltipText,
   ...props
 }: InputProps) => {
   const additionalClasses = [
@@ -28,7 +31,12 @@ export const Input: React.FC<InputProps> = ({
 
   return (
     <div className={`Input ${additionalClasses}`}>
-      {label && <label htmlFor={id}>{label}</label>}
+      {label && <div className="InputLabel__wrapper">
+        <label htmlFor={id}>{label}</label>
+        {tooltipText && (
+          <InfoButtonWithTooltip>{tooltipText}</InfoButtonWithTooltip>
+        )}
+      </div>}
 
       <div className="Input__container">
         {leftElement && (

--- a/@stellar/design-system/src/components/Input/styles.scss
+++ b/@stellar/design-system/src/components/Input/styles.scss
@@ -3,6 +3,28 @@
 .Input {
   width: 100%;
 
+  .InfoLabel {
+    &__wrapper {
+      position: relative;
+      display: flex;
+      align-items: center;
+      margin-bottom: 0.5rem;
+
+      label {
+        margin-bottom: 0;
+      }
+
+      .InfoButton {
+        margin-left: 0.5rem;
+      }
+
+      .InfoButtonTooltip {
+        right: auto;
+        left: 0;
+      }
+    }
+  }
+
   &__container {
     @include mixins.form-field-container;
   }

--- a/@stellar/design-system/src/components/Select/index.tsx
+++ b/@stellar/design-system/src/components/Select/index.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { InfoButtonWithTooltip } from "../InfoButtonWithTooltip";
 import { FieldElement } from "../utils/FieldElement";
 import { FieldNote } from "../utils/FieldNote";
 import { Icon } from "../../icons";
@@ -12,6 +13,7 @@ interface SelectProps extends React.SelectHTMLAttributes<HTMLSelectElement> {
   note?: string | React.ReactNode;
   error?: string | string;
   children: React.ReactNode;
+  tooltipText?: string | React.ReactNode;
 }
 
 export const Select: React.FC<SelectProps> = ({
@@ -22,6 +24,7 @@ export const Select: React.FC<SelectProps> = ({
   note,
   error,
   children,
+  tooltipText,
   ...props
 }: SelectProps) => {
   const additionalClasses = [
@@ -31,7 +34,12 @@ export const Select: React.FC<SelectProps> = ({
 
   return (
     <div className={`Select ${additionalClasses}`}>
-      {label && <label htmlFor={id}>{label}</label>}
+      {label && <div className="SelectLabel__wrapper">
+        <label htmlFor={id}>{label}</label>
+        {tooltipText && (
+          <InfoButtonWithTooltip>{tooltipText}</InfoButtonWithTooltip>
+        )}
+      </div>}
 
       <div className="Select__container">
         {leftElement && (

--- a/@stellar/design-system/src/components/Select/styles.scss
+++ b/@stellar/design-system/src/components/Select/styles.scss
@@ -2,6 +2,30 @@
 
 .Select {
   width: 100%;
+  
+  .SelectLabel {
+    width: 100%;
+
+    &__wrapper {
+      position: relative;
+      display: flex;
+      align-items: center;
+      margin-bottom: 0.5rem;
+
+      label {
+        margin-bottom: 0;
+      }
+
+      .InfoButton {
+        margin-left: 0.5rem;
+      }
+
+      .InfoButtonTooltip {
+        right: auto;
+        left: 0;
+      }
+    }
+  }
 
   &__container {
     @include mixins.form-field-container;
@@ -71,3 +95,4 @@
     }
   }
 }
+


### PR DESCRIPTION
These info buttons are now required in two of our projects and could conceivably be used in future projects,  so I think it is worth adding to our design system. 

I mostly copied the code from stellar/stellar-demo-wallet with small adjustments to include it in the `Select` component too. I noticed the demo wallet uses an old SDS version so there may be updated needed prior to merge.