### PR TITLE
Button small size + cleanup

### DIFF
--- a/@stellar/design-system-website/src/constants/details/buttons.tsx
+++ b/@stellar/design-system-website/src/constants/details/buttons.tsx
@@ -21,6 +21,7 @@ export const buttons: ComponentDetails = {
         <Button>Label</Button>,
         <Button disabled>Label</Button>,
         <Button isLoading>Label</Button>,
+        <Button size={Button.size.small}>Label</Button>,
       ],
     },
     {
@@ -32,6 +33,9 @@ export const buttons: ComponentDetails = {
           Label
         </Button>,
         <Button iconLeft={<Icon.Check />} isLoading>
+          Label
+        </Button>,
+        <Button iconLeft={<Icon.Check />} size={Button.size.small}>
           Label
         </Button>,
       ],
@@ -47,6 +51,9 @@ export const buttons: ComponentDetails = {
         <Button iconRight={<Icon.Check />} isLoading>
           Label
         </Button>,
+        <Button iconRight={<Icon.Check />} size={Button.size.small}>
+          Label
+        </Button>,
       ],
     },
     {
@@ -58,6 +65,9 @@ export const buttons: ComponentDetails = {
           Label
         </Button>,
         <Button variant={Button.variant.secondary} isLoading>
+          Label
+        </Button>,
+        <Button variant={Button.variant.secondary} size={Button.size.small}>
           Label
         </Button>,
       ],
@@ -80,6 +90,13 @@ export const buttons: ComponentDetails = {
           variant={Button.variant.secondary}
           iconLeft={<Icon.Check />}
           isLoading
+        >
+          Label
+        </Button>,
+        <Button
+          variant={Button.variant.secondary}
+          iconLeft={<Icon.Check />}
+          size={Button.size.small}
         >
           Label
         </Button>,
@@ -106,6 +123,13 @@ export const buttons: ComponentDetails = {
         >
           Label
         </Button>,
+        <Button
+          variant={Button.variant.secondary}
+          iconRight={<Icon.Check />}
+          size={Button.size.small}
+        >
+          Label
+        </Button>,
       ],
     },
     {
@@ -117,6 +141,9 @@ export const buttons: ComponentDetails = {
           Label
         </Button>,
         <Button variant={Button.variant.tertiary} isLoading>
+          Label
+        </Button>,
+        <Button variant={Button.variant.tertiary} size={Button.size.small}>
           Label
         </Button>,
       ],
@@ -142,6 +169,13 @@ export const buttons: ComponentDetails = {
         >
           Label
         </Button>,
+        <Button
+          variant={Button.variant.tertiary}
+          iconLeft={<Icon.Check />}
+          size={Button.size.small}
+        >
+          Label
+        </Button>,
       ],
     },
     {
@@ -162,6 +196,13 @@ export const buttons: ComponentDetails = {
           variant={Button.variant.tertiary}
           iconRight={<Icon.Check />}
           isLoading
+        >
+          Label
+        </Button>,
+        <Button
+          variant={Button.variant.tertiary}
+          iconRight={<Icon.Check />}
+          size={Button.size.small}
         >
           Label
         </Button>,
@@ -203,6 +244,13 @@ export const buttons: ComponentDetails = {
       default: "primary",
       optional: true,
       description: "Variant of the button",
+    },
+    {
+      prop: "size",
+      type: ["default", "small"],
+      default: "default",
+      optional: true,
+      description: "Size of the button",
     },
   ],
   externalProps: {

--- a/@stellar/design-system-website/src/generated/gitInfo.ts
+++ b/@stellar/design-system-website/src/generated/gitInfo.ts
@@ -1,1 +1,1 @@
-export default {"commitHash": "ef32376"};
+export default { commitHash: "de3d86b" };

--- a/@stellar/design-system/src/components/Button/index.tsx
+++ b/@stellar/design-system/src/components/Button/index.tsx
@@ -9,15 +9,22 @@ enum ButtonVariant {
   tertiary = "tertiary",
 }
 
+enum ButtonSize {
+  default = "default",
+  small = "small",
+}
+
 interface ButtonComponent {
   variant: typeof ButtonVariant;
+  size: typeof ButtonSize;
 }
 
 interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   iconLeft?: React.ReactNode;
   iconRight?: React.ReactNode;
   variant?: ButtonVariant;
-  isLoading?: Boolean;
+  isLoading?: boolean;
+  size?: ButtonSize;
   children: string | React.ReactNode;
 }
 
@@ -26,24 +33,35 @@ export const Button: React.FC<ButtonProps> & ButtonComponent = ({
   iconRight,
   variant = ButtonVariant.primary,
   isLoading,
+  size = ButtonSize.default,
   children,
   ...props
-}) => (
-  <button
-    className={`Button Button--${variant}`}
-    {...props}
-    {...(isLoading ? { disabled: true } : {})}
-  >
-    {iconLeft ? (
-      <ButtonIcon position={ButtonIcon.position.left}>{iconLeft}</ButtonIcon>
-    ) : null}
-    {children}
-    {iconRight ? (
-      <ButtonIcon position={ButtonIcon.position.right}>{iconRight}</ButtonIcon>
-    ) : null}
-    {isLoading ? <Loader /> : null}
-  </button>
-);
+}) => {
+  const additionalClasses = [
+    `Button--${variant}`,
+    ...(size !== ButtonSize.default ? [`Button--${size}`] : []),
+  ].join(" ");
+
+  return (
+    <button
+      className={`Button ${additionalClasses}`}
+      {...props}
+      {...(isLoading ? { disabled: true } : {})}
+    >
+      {iconLeft ? (
+        <ButtonIcon position={ButtonIcon.position.left}>{iconLeft}</ButtonIcon>
+      ) : null}
+      {children}
+      {iconRight ? (
+        <ButtonIcon position={ButtonIcon.position.right}>
+          {iconRight}
+        </ButtonIcon>
+      ) : null}
+      {isLoading ? <Loader /> : null}
+    </button>
+  );
+};
 
 Button.displayName = "Button";
 Button.variant = ButtonVariant;
+Button.size = ButtonSize;

--- a/@stellar/design-system/src/components/Button/styles.scss
+++ b/@stellar/design-system/src/components/Button/styles.scss
@@ -13,7 +13,7 @@
   --Button-color-background: transparent;
   --Button-color-border: transparent;
 
-  font-size: 1rem;
+  font-size: var(--font-size);
   line-height: 1.56rem;
   padding: 0.6rem 1.5rem;
   font-weight: var(--font-weight-medium);
@@ -27,6 +27,13 @@
   background-color: var(--Button-color-background);
   color: var(--Button-color-text);
   transition: background-color var(--anim-transition-default);
+
+  &--small {
+    font-size: var(--font-size-secondary);
+    line-height: 1.5rem;
+    padding: 0.25rem 0.75rem;
+    font-weight: var(--font-weight-medium);
+  }
 
   &--primary {
     --Button-color-background: var(--pal-brand-primary);

--- a/@stellar/design-system/src/components/Layout/index.tsx
+++ b/@stellar/design-system/src/components/Layout/index.tsx
@@ -13,7 +13,9 @@ interface LayoutComponent {
   Footer: React.FC<FooterProps>;
 }
 
-export const Layout: LayoutComponent = () => {};
+export const Layout: LayoutComponent = () => {
+  // do nothing
+};
 
 interface InsetProps {
   children: React.ReactNode;

--- a/@stellar/design-system/src/components/TextLink/index.tsx
+++ b/@stellar/design-system/src/components/TextLink/index.tsx
@@ -15,8 +15,8 @@ interface TextLinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
   iconLeft?: React.ReactNode;
   iconRight?: React.ReactNode;
   variant?: TextLinkVariant;
-  disabled?: Boolean;
-  underline?: Boolean;
+  disabled?: boolean;
+  underline?: boolean;
   children: string | React.ReactNode;
 }
 


### PR DESCRIPTION
- Add optional `size` prop to Button component (default size did not change).
- Small cleanup

![image](https://user-images.githubusercontent.com/7346473/135469931-7c007f91-9aae-4f60-b5a0-9f0e739cb06c.png)
