### PR TITLE
Replace RGBA colors with solid colors

### DIFF
--- a/@stellar/design-system-website/src/generated/gitInfo.ts
+++ b/@stellar/design-system-website/src/generated/gitInfo.ts
@@ -1,1 +1,1 @@
-export default {"commitHash": "ef32376"};
+export default { commitHash: "de3d86b" };

--- a/@stellar/design-system/src/components/InfoBlock/index.tsx
+++ b/@stellar/design-system/src/components/InfoBlock/index.tsx
@@ -31,10 +31,8 @@ export const InfoBlock: React.FC<InfoBlockProps> & InfoBlockComponent = ({
 
   return (
     <div className={`InfoBlock InfoBlock--${variant}`}>
-      <div className="InfoBlock__content">
-        <div className="InfoBlock__icon">{variantIcon[variant]}</div>
-        {children}
-      </div>
+      <div className="InfoBlock__icon">{variantIcon[variant]}</div>
+      {children}
     </div>
   );
 };

--- a/@stellar/design-system/src/components/InfoBlock/styles.scss
+++ b/@stellar/design-system/src/components/InfoBlock/styles.scss
@@ -1,8 +1,8 @@
 @use "../../mixins.scss";
 
-@mixin info-block($bg, $icon) {
-  background-color: rgba($bg, 0.16);
-  border-color: rgba($bg, 0.4);
+@mixin info-block($bg, $border, $icon) {
+  background-color: $bg;
+  border-color: $border;
 
   svg {
     @include mixins.svg-color($icon);
@@ -10,42 +10,45 @@
 }
 
 .InfoBlock {
-  border-radius: 0.25rem;
   width: 100%;
-  background-color: var(--pal-background-primary);
-
-  &__content {
-    border-radius: 0.25rem;
-    border: 1px solid transparent;
-    padding: 1rem;
-    padding-left: 2.5rem;
-    line-height: 1.75rem;
-    position: relative;
-    color: var(--pal-text-secondary);
-  }
+  border: 1px solid transparent;
+  border-radius: 0.25rem;
+  padding: 1rem;
+  padding-left: 2.5rem;
+  line-height: 1.75rem;
+  position: relative;
+  color: var(--pal-text-secondary);
 
   &--info {
-    .InfoBlock__content {
-      @include info-block(var(--pal-brand-primary-rgb), var(--pal-text-link));
-    }
+    @include info-block(
+      var(--pal-info-background),
+      var(--pal-info-border),
+      var(--pal-info)
+    );
   }
 
   &--success {
-    .InfoBlock__content {
-      @include info-block(var(--pal-success-rgb), rgb(var(--pal-success-rgb)));
-    }
+    @include info-block(
+      var(--pal-success-background),
+      var(--pal-success-border),
+      var(--pal-success)
+    );
   }
 
   &--error {
-    .InfoBlock__content {
-      @include info-block(var(--pal-error-rgb), rgb(var(--pal-error-rgb)));
-    }
+    @include info-block(
+      var(--pal-error-background),
+      var(--pal-error-border),
+      var(--pal-error)
+    );
   }
 
   &--warning {
-    .InfoBlock__content {
-      @include info-block(var(--pal-warning-rgb), rgb(var(--pal-warning-rgb)));
-    }
+    @include info-block(
+      var(--pal-warning-background),
+      var(--pal-warning-border),
+      var(--pal-warning)
+    );
   }
 
   &__icon {

--- a/@stellar/design-system/src/components/StatusBar/index.tsx
+++ b/@stellar/design-system/src/components/StatusBar/index.tsx
@@ -23,9 +23,7 @@ export const StatusBar: React.FC<StatusBarProps> & StatusBarComponent = ({
   children,
 }) => (
   <div className={`StatusBar StatusBar--${variant}`}>
-    <div className="StatusBar__content">
-      <Layout.Inset>{children}</Layout.Inset>
-    </div>
+    <Layout.Inset>{children}</Layout.Inset>
   </div>
 );
 

--- a/@stellar/design-system/src/components/StatusBar/styles.scss
+++ b/@stellar/design-system/src/components/StatusBar/styles.scss
@@ -1,33 +1,35 @@
-@mixin status-bar($color) {
-  background-color: rgba($color, 0.16);
-  border-bottom: 1px solid rgba($color, 0.4);
+@mixin status-bar($bg, $border) {
+  background-color: $bg;
+  border-bottom: 1px solid $border;
 }
 
 .StatusBar {
   width: 100%;
-  background-color: var(--pal-background-primary);
-
-  &__content {
-    padding: 0.5rem 0;
-    text-align: center;
-    color: var(--pal-text-secondary);
-    font-size: 1rem;
-    line-height: 1.5rem;
-  }
+  padding: 0.5rem 0;
+  text-align: center;
+  color: var(--pal-text-secondary);
+  font-size: 1rem;
+  line-height: 1.5rem;
 
   &--info {
-    @include status-bar(var(--pal-brand-primary-rgb));
+    @include status-bar(var(--pal-info-background), var(--pal-info-border));
   }
 
   &--success {
-    @include status-bar(var(--pal-success-rgb));
+    @include status-bar(
+      var(--pal-success-background),
+      var(--pal-success-border)
+    );
   }
 
   &--error {
-    @include status-bar(var(--pal-error-rgb));
+    @include status-bar(var(--pal-error-background), var(--pal-error-border));
   }
 
   &--warning {
-    @include status-bar(var(--pal-warning-rgb));
+    @include status-bar(
+      var(--pal-warning-background),
+      var(--pal-warning-border)
+    );
   }
 }

--- a/@stellar/design-system/src/components/Tag/styles.scss
+++ b/@stellar/design-system/src/components/Tag/styles.scss
@@ -1,3 +1,8 @@
+@mixin tag($color, $bg) {
+  color: $color;
+  background-color: $bg;
+}
+
 .Tag {
   font-size: 0.875rem;
   line-height: 1.375rem;
@@ -6,28 +11,23 @@
   padding: 0 0.375rem;
   border-radius: 0.125rem;
 
-  &.Tag--default {
-    color: var(--pal-text-secondary);
-    background-color: rgba(var(--pal-text-base-rgb), 0.08);
+  &--default {
+    @include tag(var(--pal-text-secondary), var(--pal-background-secondary));
   }
 
-  &.Tag--highlight {
-    color: var(--pal-text-link);
-    background-color: rgba(var(--pal-brand-primary-rgb), 0.1);
+  &--highlight {
+    @include tag(var(--pal-info), var(--pal-info-background));
   }
 
-  &.Tag--success {
-    color: var(--pal-success);
-    background-color: rgba(var(--pal-success-rgb), 0.08);
+  &--success {
+    @include tag(var(--pal-success), var(--pal-success-background));
   }
 
-  &.Tag--error {
-    color: var(--pal-error);
-    background-color: rgba(var(--pal-error-rgb), 0.08);
+  &--error {
+    @include tag(var(--pal-error), var(--pal-error-background));
   }
 
-  &.Tag--warning {
-    color: var(--pal-warning);
-    background-color: rgba(var(--pal-warning-rgb), 0.08);
+  &--warning {
+    @include tag(var(--pal-warning), var(--pal-warning-background));
   }
 }

--- a/@stellar/design-system/src/components/Tooltip/styles.scss
+++ b/@stellar/design-system/src/components/Tooltip/styles.scss
@@ -1,15 +1,14 @@
 .Tooltip {
   position: absolute;
-  background-color: var(--pal-background-primary);
   max-width: 16.875rem;
   border-radius: 0.125rem;
-  border: 1px solid rgba(var(--pal-brand-primary-rgb), 0.4);
+  border: 1px solid var(--pal-info-border);
   z-index: var(--z-index-tooltip);
   cursor: default;
 
   &__content {
     padding: 0.5rem 1rem;
-    background-color: rgba(var(--pal-brand-primary-rgb), 0.16);
+    background-color: var(--pal-info-background);
     color: var(--pal-text-secondary);
     font-size: var(--font-size-secondary);
     line-height: 1.5em;

--- a/@stellar/design-system/src/global.scss
+++ b/@stellar/design-system/src/global.scss
@@ -1,9 +1,6 @@
 @mixin light-theme-palette {
   --pal-brand-primary: #3e1bdb;
-  // -rgb color is needed for rgba(). Hex color CSS variable doesn't work.
-  --pal-brand-primary-rgb: 62, 27, 219;
   --pal-brand-primary-hover: #241080;
-  --pal-brand-primary-hover-rgb: 36, 16, 128;
   --pal-brand-primary-on: #ffffff;
 
   --pal-background-primary: #ffffff;
@@ -11,25 +8,33 @@
   --pal-background-tertiary: #f2f2f2;
 
   --pal-success: #20bf6b;
-  --pal-success-rgb: 32, 191, 107;
+  --pal-success-background: #dbf5e7;
+  --pal-success-border: #90dfb5;
   --pal-success-on: #ffffff;
+
   --pal-error: #eb3b5a;
-  --pal-error-rgb: 235, 59, 90;
+  --pal-error-background: #fce0e5;
+  --pal-error-border: #f59ead;
   --pal-error-on: #ffffff;
+
   --pal-warning: #f7b731;
-  --pal-warning-rgb: 247, 183, 49;
+  --pal-warning-background: #fef3de;
+  --pal-warning-border: #fbdb99;
   --pal-warning-on: #ffffff;
 
-  --pal-text-base-rgb: 0, 0, 0;
-  --pal-text-primary: rgba(var(--pal-text-base-rgb), 1);
-  --pal-text-secondary: rgba(var(--pal-text-base-rgb), 0.6);
-  --pal-text-tertiary: rgba(var(--pal-text-base-rgb), 0.4);
+  --pal-info: #5332e6;
+  --pal-info-background: #e0dbf9;
+  --pal-info-border: #9f8eed;
+  --pal-info-on: #ffffff;
+
+  --pal-text-primary: #000000;
+  --pal-text-secondary: #333333;
+  --pal-text-tertiary: #666666;
   --pal-text-link: #5332e6;
   --pal-text-link-hover: #241080;
 
-  --pal-border-base-rgb: 0, 0, 0;
-  --pal-border-primary: rgba(var(--pal-text-base-rgb), 0.08);
-  --pal-border-secondary: rgba(var(--pal-text-base-rgb), 0.16);
+  --pal-border-primary: #ebebeb;
+  --pal-border-secondary: #e7e7e7;
 
   --pal-shadow-rbg: 0, 0, 0;
 
@@ -39,10 +44,7 @@
 
 @mixin dark-theme-palette {
   --pal-brand-primary: #5332e6;
-  // -rgb color is needed for rgba(). Hex color CSS variable doesn't work.
-  --pal-brand-primary-rgb: 83, 50, 230;
   --pal-brand-primary-hover: #937eef;
-  --pal-brand-primary-hover-rgb: 147, 126, 239;
   --pal-brand-primary-on: #ffffff;
 
   --pal-background-primary: #292d3e;
@@ -50,25 +52,33 @@
   --pal-background-tertiary: #222634;
 
   --pal-success: #26db7b;
-  --pal-success-rgb: 38, 219, 123;
+  --pal-success-background: #284445;
+  --pal-success-border: #257554;
   --pal-success-on: #ffffff;
+
   --pal-error: #ee5a74;
-  --pal-error-rgb: 238, 90, 116;
+  --pal-error-background: #482f42;
+  --pal-error-border: #89344c;
   --pal-error-on: #ffffff;
+
   --pal-warning: #f8c252;
-  --pal-warning-rgb: 248, 194, 82;
+  --pal-warning-background: #4a433c;
+  --pal-warning-border: #8f7138;
   --pal-warning-on: #ffffff;
 
-  --pal-text-base-rgb: 255, 255, 255;
-  --pal-text-primary: rgba(var(--pal-text-base-rgb), 1);
-  --pal-text-secondary: rgba(var(--pal-text-base-rgb), 0.6);
-  --pal-text-tertiary: rgba(var(--pal-text-base-rgb), 0.4);
+  --pal-info: #6260eb;
+  --pal-info-background: #2c2a57;
+  --pal-info-border: #33248c;
+  --pal-info-on: #ffffff;
+
+  --pal-text-primary: #ffffff;
+  --pal-text-secondary: #cccccc;
+  --pal-text-tertiary: #999999;
   --pal-text-link: #6260eb;
   --pal-text-link-hover: #937eef;
 
-  --pal-border-base-rgb: 255, 255, 255;
-  --pal-border-primary: rgba(var(--pal-text-base-rgb), 0.08);
-  --pal-border-secondary: rgba(var(--pal-text-base-rgb), 0.16);
+  --pal-border-primary: #3a3e4d;
+  --pal-border-secondary: #4b4f5d;
 
   --pal-shadow-rbg: 0, 0, 0;
 


### PR DESCRIPTION
Replacing RGBA colors with solid colors to make sure colors are eligible in every scenario. This update should not break anything unless `-rgb` colors are used directly in local projects.

Updated components (colors + some cleanup):
- `InfoBlock`
- `StatusBar`
- `Tag`
- `Tooltip`