### PR TITLE
Tweaks and fixes

### DIFF
--- a/@stellar/design-system-website/src/constants/details/inputs.tsx
+++ b/@stellar/design-system-website/src/constants/details/inputs.tsx
@@ -99,7 +99,7 @@ export const inputs: ComponentDetails = {
     },
     {
       prop: "label",
-      type: ["string"],
+      type: ["string", "ReactNode"],
       default: null,
       optional: true,
       description: "Label of the input",

--- a/@stellar/design-system-website/src/constants/details/selects.tsx
+++ b/@stellar/design-system-website/src/constants/details/selects.tsx
@@ -95,7 +95,7 @@ export const selects: ComponentDetails = {
     },
     {
       prop: "label",
-      type: ["string"],
+      type: ["string", "ReactNode"],
       default: null,
       optional: true,
       description: "Label of the select",

--- a/@stellar/design-system-website/src/constants/details/tables.tsx
+++ b/@stellar/design-system-website/src/constants/details/tables.tsx
@@ -126,6 +126,13 @@ export const tables: ComponentDetails = {
   ],
   props: [
     {
+      prop: "id",
+      type: ["string"],
+      default: "table",
+      optional: true,
+      description: "Optional ID used for row keys",
+    },
+    {
       prop: "data",
       type: ["T[]"],
       default: null,

--- a/@stellar/design-system-website/src/generated/gitInfo.ts
+++ b/@stellar/design-system-website/src/generated/gitInfo.ts
@@ -1,1 +1,1 @@
-export default { commitHash: "f749f91" };
+export default { commitHash: "6f4399e" };

--- a/@stellar/design-system/src/components/Input/index.tsx
+++ b/@stellar/design-system/src/components/Input/index.tsx
@@ -5,7 +5,7 @@ import "./styles.scss";
 
 interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
   id: string;
-  label?: string;
+  label?: string | React.ReactNode;
   leftElement?: string | React.ReactNode;
   rightElement?: string | React.ReactNode;
   note?: string | React.ReactNode;

--- a/@stellar/design-system/src/components/Select/index.tsx
+++ b/@stellar/design-system/src/components/Select/index.tsx
@@ -6,7 +6,7 @@ import "./styles.scss";
 
 interface SelectProps extends React.SelectHTMLAttributes<HTMLSelectElement> {
   id: string;
-  label?: string;
+  label?: string | React.ReactNode;
   leftElement?: string | React.ReactNode;
   rightElement?: string | React.ReactNode;
   note?: string | React.ReactNode;

--- a/@stellar/design-system/src/components/Table/index.tsx
+++ b/@stellar/design-system/src/components/Table/index.tsx
@@ -15,6 +15,7 @@ interface TableColumnLabel {
 }
 
 interface TableProps<T> {
+  id?: string;
   data: T[];
   columnLabels: TableColumnLabel[];
   renderItemRow: (item: T) => React.ReactElement;
@@ -25,6 +26,7 @@ interface TableProps<T> {
 }
 
 export const Table = <T extends Record<string, any>>({
+  id = "table",
   data,
   columnLabels,
   renderItemRow,
@@ -138,7 +140,7 @@ export const Table = <T extends Record<string, any>>({
                   /* eslint-disable react/no-array-index-key */
                   <tr
                     className={item.href ? `Table__clickableRow` : ""}
-                    key={`row-${index}`}
+                    key={`${id}-row-${index}`}
                     onClick={() => (item.href ? history.push(item.href) : null)}
                   >
                     {hideNumberColumn ? null : (

--- a/@stellar/design-system/src/components/Tooltip/index.tsx
+++ b/@stellar/design-system/src/components/Tooltip/index.tsx
@@ -100,7 +100,7 @@ export const Tooltip: React.FC<TooltipProps> & TooltipComponent = ({
   }, [isTooltipVisible, handleClickOutside, disableClick]);
 
   return (
-    <div className="Tooltip">
+    <div className={`Tooltip ${isTooltipVisible ? "Tooltip--opened" : ""}`}>
       <div
         ref={referenceEl}
         className="Tooltip__component"

--- a/@stellar/design-system/src/components/Tooltip/styles.scss
+++ b/@stellar/design-system/src/components/Tooltip/styles.scss
@@ -6,6 +6,10 @@
   z-index: var(--z-index-tooltip);
   display: inline-block;
 
+  &--opened {
+    z-index: calc(var(--z-index-tooltip) + 1);
+  }
+
   &__content {
     width: max-content;
     max-width: 16.875rem;


### PR DESCRIPTION
- Add optional `id` prop to Table component, used when multiple Table components are on the same page.
- Fix Tooltip overlapping bug (https://github.com/stellar/stellar-design-system/issues/86)
- Input and Select component labels can be `ReactNode` (not just strings) (https://github.com/stellar/stellar-design-system/issues/87)