### PR TITLE
Release 0.8.0

### DIFF
--- a/.github/workflows/update_deps.yml
+++ b/.github/workflows/update_deps.yml
@@ -1,8 +1,8 @@
 name: Monthly dependency updates
 on:
   schedule:
-    # First of every month
-    - cron: 0 0 1 * *
+    # First of every other month
+    - cron: 0 0 1 */2 *
 
 jobs:
   create_issue:
@@ -22,6 +22,7 @@ jobs:
             ```
             Make sure there are no issues in the code editor, code compiles, and it runs without issues in the browser.
           pinned: false
-          close-previous: false
+          close-previous: true
+          labels: "design-system, dependencies"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/@stellar/design-system-website/package.json
+++ b/@stellar/design-system-website/package.json
@@ -13,7 +13,7 @@
     "lint-tsc": "tsc --noEmit"
   },
   "dependencies": {
-    "@stellar/design-system": "^0.7.0",
+    "@stellar/design-system": "^0.8.0",
     "lodash": "^4.17.21",
     "prism-react-renderer": "^1.2.1",
     "react": "^17.0.2",

--- a/@stellar/design-system-website/src/components/Details/styles.scss
+++ b/@stellar/design-system-website/src/components/Details/styles.scss
@@ -35,10 +35,6 @@
       justify-content: flex-start;
       align-items: center;
       flex-wrap: wrap;
-
-      .TableContainer .Table {
-        --table-min-width: 400px;
-      }
     }
 
     &__code {

--- a/@stellar/design-system-website/src/constants/componentDetails.ts
+++ b/@stellar/design-system-website/src/constants/componentDetails.ts
@@ -21,6 +21,7 @@ import { selects } from "constants/details/selects";
 import { statusBars } from "constants/details/statusBars";
 import { tables } from "constants/details/tables";
 import { tags } from "constants/details/tags";
+import { textareas } from "constants/details/textareas";
 import { textLinks } from "constants/details/textLinks";
 import { toggles } from "constants/details/toggles";
 import { tooltips } from "constants/details/tooltips";
@@ -51,6 +52,7 @@ export const componentDetails: ComponentDetailsList = {
   statusBars,
   tables,
   tags,
+  textareas,
   textLinks,
   toggles,
   tooltips,

--- a/@stellar/design-system-website/src/constants/componentsInDisplayOrder.ts
+++ b/@stellar/design-system-website/src/constants/componentsInDisplayOrder.ts
@@ -63,6 +63,10 @@ export const componentsInDisplayOrder: ComponentsInDisplayOrder[] = [
     label: "Selects",
   },
   {
+    id: ComponentDetailsId.textareas,
+    label: "Textareas",
+  },
+  {
     id: ComponentDetailsId.checkboxes,
     label: "Checkboxes",
   },

--- a/@stellar/design-system-website/src/constants/details/checkboxes.tsx
+++ b/@stellar/design-system-website/src/constants/details/checkboxes.tsx
@@ -50,6 +50,22 @@ export const checkboxes: ComponentDetails = {
         />,
       ],
     },
+    {
+      title: "Checkbox with note / error",
+      description: "",
+      component: [
+        <Checkbox
+          id="checkbox-7"
+          label="Lorem ipsum dolor sit amet consectetur adipisicing elit. Quia reprehenderit ipsam facilis"
+          note="Note message"
+        />,
+        <Checkbox
+          id="checkbox-8"
+          label="Illum odio veritatis corporis nihil asperiores eum nam in error"
+          error="Error message"
+        />,
+      ],
+    },
   ],
   props: [
     {
@@ -65,6 +81,20 @@ export const checkboxes: ComponentDetails = {
       default: null,
       optional: true,
       description: "Label of the checkbox",
+    },
+    {
+      prop: "note",
+      type: ["string", "ReactNode"],
+      default: null,
+      optional: true,
+      description: "Note message of the checkbox",
+    },
+    {
+      prop: "error",
+      type: ["string", "ReactNode"],
+      default: null,
+      optional: true,
+      description: "Error message of the checkbox",
     },
   ],
   externalProps: {

--- a/@stellar/design-system-website/src/constants/details/copyTexts.tsx
+++ b/@stellar/design-system-website/src/constants/details/copyTexts.tsx
@@ -1,4 +1,4 @@
-import { CopyText, TextLink } from "@stellar/design-system";
+import { CopyText, TextLink, IconButton } from "@stellar/design-system";
 import { ComponentDetails, ComponentDetailsId } from "types/types.d";
 
 export const copyTexts: ComponentDetails = {
@@ -32,16 +32,18 @@ export const copyTexts: ComponentDetails = {
       ],
     },
     {
-      title: "With copy icon",
+      title: "Using Icon button copy preset",
       description: "Text link with copy icon and tooltip",
       component: [
         <CopyText
           textToCopy="Test copy"
-          showCopyIcon
           showTooltip
           tooltipPosition={CopyText.tooltipPosition.RIGHT}
         >
-          <TextLink>Copy</TextLink>
+          <IconButton
+            preset={IconButton.preset.copy}
+            variant={IconButton.variant.highlight}
+          />
         </CopyText>,
       ],
     },
@@ -53,13 +55,6 @@ export const copyTexts: ComponentDetails = {
       default: null,
       optional: false,
       description: "Text to copy",
-    },
-    {
-      prop: "showCopyIcon",
-      type: ["boolean"],
-      default: null,
-      optional: true,
-      description: "Flag to enable copy icon",
     },
     {
       prop: "showTooltip",

--- a/@stellar/design-system-website/src/constants/details/iconButtons.tsx
+++ b/@stellar/design-system-website/src/constants/details/iconButtons.tsx
@@ -9,7 +9,8 @@ export const iconButtons: ComponentDetails = {
       <code>IconButton</code> is similar to the <code>Button</code>, and is used
       to trigger an action. There are five variants (color is the only
       difference): <code>default</code>, <code>error</code>,{" "}
-      <code>success</code>, <code>warning</code>, <code>highlight</code>.
+      <code>success</code>, <code>warning</code>, <code>highlight</code>; and
+      two presets: <code>copy</code> and <code>download</code>.
     </>
   ),
   shortDescription: "Similar to the Button, and is used to trigger an action",
@@ -20,6 +21,19 @@ export const iconButtons: ComponentDetails = {
       component: [
         <IconButton icon={<Icon.Info />} altText="Default" />,
         <IconButton icon={<Icon.Info />} altText="Default" disabled />,
+      ],
+    },
+    {
+      title: "Default with label",
+      description: "",
+      component: [
+        <IconButton icon={<Icon.Info />} label="Default" altText="Default" />,
+        <IconButton
+          icon={<Icon.Info />}
+          label="Default"
+          altText="Default"
+          disabled
+        />,
       ],
     },
     {
@@ -91,6 +105,36 @@ export const iconButtons: ComponentDetails = {
       ],
     },
     {
+      title: "Preset: copy",
+      description: "",
+      component: [
+        <IconButton
+          preset={IconButton.preset.copy}
+          variant={IconButton.variant.highlight}
+        />,
+        <IconButton
+          preset={IconButton.preset.copy}
+          variant={IconButton.variant.highlight}
+          disabled
+        />,
+      ],
+    },
+    {
+      title: "Preset: download",
+      description: "",
+      component: [
+        <IconButton
+          preset={IconButton.preset.download}
+          variant={IconButton.variant.highlight}
+        />,
+        <IconButton
+          preset={IconButton.preset.download}
+          variant={IconButton.variant.highlight}
+          disabled
+        />,
+      ],
+    },
+    {
       title: "Custom color",
       description: "",
       component: [
@@ -124,8 +168,34 @@ export const iconButtons: ComponentDetails = {
         />,
       ],
     },
+    {
+      title: "Custom size with label",
+      description: "",
+      component: [
+        <IconButton
+          icon={<Icon.Info />}
+          altText="Custom size"
+          label="Custom"
+          customSize="2rem"
+        />,
+        <IconButton
+          icon={<Icon.Info />}
+          altText="Custom size"
+          label="Custom"
+          customSize="2rem"
+          disabled
+        />,
+      ],
+    },
   ],
   props: [
+    {
+      prop: "IconButtonDefaultProps",
+      type: [],
+      default: null,
+      optional: false,
+      description: "",
+    },
     {
       prop: "icon",
       type: ["ReactNode"],
@@ -141,11 +211,39 @@ export const iconButtons: ComponentDetails = {
       description: "Alternative text to show on hover",
     },
     {
+      prop: "IconButtonPresetProps",
+      type: [],
+      default: null,
+      optional: false,
+      description: "",
+    },
+    {
+      prop: "preset",
+      type: ["copy", "download"],
+      default: null,
+      optional: false,
+      description: "Predefined set of icon buttons",
+    },
+    {
+      prop: "IconButtonBaseProps",
+      type: [],
+      default: null,
+      optional: false,
+      description: "",
+    },
+    {
       prop: "variant",
       type: ["default", "error", "success", "warning", "highlight"],
       default: "default",
       optional: true,
       description: "Variant of the component",
+    },
+    {
+      prop: "label",
+      type: ["string"],
+      default: null,
+      optional: true,
+      description: "Component label",
     },
     {
       prop: "customColor",

--- a/@stellar/design-system-website/src/constants/details/mocks.tsx
+++ b/@stellar/design-system-website/src/constants/details/mocks.tsx
@@ -1,2 +1,4 @@
 // used to illustrate a Formik <Field /> in examples
 export const Field = (props: any) => <input {...props} />;
+
+export const TextareaField = (props: any) => <textarea {...props} />;

--- a/@stellar/design-system-website/src/constants/details/tables.tsx
+++ b/@stellar/design-system-website/src/constants/details/tables.tsx
@@ -84,6 +84,7 @@ export const tables: ComponentDetails = {
           data={tableData}
           renderItemRow={renderItemRow}
           hideNumberColumn
+          breakpoint={400}
         />,
       ],
     },
@@ -96,6 +97,7 @@ export const tables: ComponentDetails = {
           data={tableData}
           renderItemRow={renderItemRow}
           pageSize={2}
+          breakpoint={400}
         />,
       ],
     },
@@ -108,6 +110,7 @@ export const tables: ComponentDetails = {
           data={tableData}
           renderItemRow={renderItemRow}
           pageSize={2}
+          breakpoint={400}
           isLoading
         />,
       ],
@@ -120,6 +123,7 @@ export const tables: ComponentDetails = {
           columnLabels={sortableTableLabels}
           data={[]}
           renderItemRow={renderItemRow}
+          breakpoint={400}
         />,
       ],
     },
@@ -152,6 +156,13 @@ export const tables: ComponentDetails = {
       default: null,
       optional: false,
       description: "Function to render table rows",
+    },
+    {
+      prop: "breakpoint",
+      type: ["300", "400", "500", "600", "700", "800", "900"],
+      default: null,
+      optional: false,
+      description: "Media query breakpoint to show sticky column layout",
     },
     {
       prop: "hideNumberColumn",

--- a/@stellar/design-system-website/src/constants/details/textareas.tsx
+++ b/@stellar/design-system-website/src/constants/details/textareas.tsx
@@ -1,0 +1,137 @@
+import { Textarea } from "@stellar/design-system";
+import { ComponentDetails, ComponentDetailsId } from "types/types.d";
+
+import { TextareaField } from "./mocks";
+
+export const textareas: ComponentDetails = {
+  id: ComponentDetailsId.textareas,
+  title: "Textareas",
+  description: (
+    <>
+      <code>Textarea</code> component is a multi-line text input element, which
+      inherits all native HTML <code>textarea</code> element attributes.
+    </>
+  ),
+  shortDescription:
+    "Multi-line text input element, which inherits all native HTML textarea element attributes",
+  examples: [
+    {
+      title: "Default",
+      description: "",
+      component: [
+        <Textarea id="textarea-1">
+          Lorem ipsum dolor sit, amet consectetur adipisicing elit. Corrupti
+          totam ut iure
+        </Textarea>,
+        <Textarea id="textarea-2" disabled>
+          Lorem ipsum dolor sit, amet consectetur adipisicing elit. Corrupti
+          totam ut iure
+        </Textarea>,
+      ],
+    },
+    {
+      title: "Textarea with label and placeholder",
+      description: "",
+      component: [
+        <Textarea id="textarea-3" label="Label" placeholder="Placeholder" />,
+        <Textarea
+          id="textarea-4"
+          label="Label"
+          placeholder="Placeholder"
+          disabled
+        />,
+      ],
+    },
+    {
+      title: "Textarea with label and long text",
+      description: "",
+      component: [
+        <Textarea id="textarea-5" label="Label" rows={5}>
+          Lorem ipsum dolor sit, amet consectetur adipisicing elit. Dolorum
+          neque veniam repudiandae fugit labore. Voluptatibus deserunt animi
+          porro esse, dolor dolore quas fuga numquam. Quisquam aperiam earum
+          suscipit nihil eaque!
+        </Textarea>,
+        <Textarea id="textarea-6" label="Label" rows={5} disabled>
+          Lorem ipsum dolor sit, amet consectetur adipisicing elit. Dolorum
+          neque veniam repudiandae fugit labore. Voluptatibus deserunt animi
+          porro esse, dolor dolore quas fuga numquam. Quisquam aperiam earum
+          suscipit nihil eaque!
+        </Textarea>,
+      ],
+    },
+    {
+      title: "Textarea with label and note / error",
+      description: "",
+      component: [
+        <Textarea id="textarea-7" label="Label" note="Note message">
+          Voluptatibus deserunt animi porro esse, dolor dolore quas fuga numquam
+        </Textarea>,
+        <Textarea id="textarea-8" label="Label" error="Error message">
+          Voluptatibus deserunt animi porro esse, dolor dolore quas fuga numquam
+        </Textarea>,
+      ],
+    },
+    {
+      title: "Textarea with custom input",
+      description: "",
+      component: [
+        <Textarea
+          customTextarea={<TextareaField />}
+          id="textarea-12"
+          label="Label"
+          placeholder="Placeholder"
+        />,
+      ],
+    },
+  ],
+  props: [
+    {
+      prop: "id",
+      type: ["string"],
+      default: null,
+      optional: false,
+      description: "ID of the textarea should be unique",
+    },
+    {
+      prop: "children",
+      type: ["string"],
+      default: "",
+      optional: true,
+      description: "Content of the textarea",
+    },
+    {
+      prop: "label",
+      type: ["string", "ReactNode"],
+      default: null,
+      optional: true,
+      description: "Label of the textarea",
+    },
+    {
+      prop: "note",
+      type: ["string", "ReactNode"],
+      default: null,
+      optional: true,
+      description: "Note message of the textarea",
+    },
+    {
+      prop: "error",
+      type: ["string", "ReactNode"],
+      default: null,
+      optional: true,
+      description: "Error message of the textarea",
+    },
+    {
+      prop: "customTextarea",
+      type: ["React.ReactNode"],
+      default: null,
+      optional: true,
+      description:
+        "Use a specific textarea rather than a generic HTML textarea (useful for Formik or otherwise controlled inputs)",
+    },
+  ],
+  externalProps: {
+    link: "https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attributes",
+    label: "textarea attributes",
+  },
+};

--- a/@stellar/design-system-website/src/constants/details/toggles.tsx
+++ b/@stellar/design-system-website/src/constants/details/toggles.tsx
@@ -167,6 +167,22 @@ export const toggles: ComponentDetails = {
         <Toggle customInput={<Field />} checked={true} id="toggle-13" />,
       ],
     },
+    {
+      title: "Toggle in settings",
+      description: "",
+      component: [
+        <div>
+          <label htmlFor="toggle-14">Setting label</label>
+          <Toggle
+            id="toggle-14"
+            checked={false}
+            onChange={() => {
+              // change state
+            }}
+          />
+        </div>,
+      ],
+    },
   ],
   props: [
     {

--- a/@stellar/design-system-website/src/generated/gitInfo.ts
+++ b/@stellar/design-system-website/src/generated/gitInfo.ts
@@ -1,1 +1,1 @@
-export default { commitHash: "46f21dc" };
+export default { commitHash: "114d9cd" };

--- a/@stellar/design-system-website/src/generated/gitInfo.ts
+++ b/@stellar/design-system-website/src/generated/gitInfo.ts
@@ -1,1 +1,1 @@
-export default { commitHash: "114d9cd" };
+export default { commitHash: "d2c5d54" };

--- a/@stellar/design-system-website/src/generated/gitInfo.ts
+++ b/@stellar/design-system-website/src/generated/gitInfo.ts
@@ -1,1 +1,1 @@
-export default { commitHash: "2b4efff" };
+export default { commitHash: "46f21dc" };

--- a/@stellar/design-system-website/src/types/types.d.ts
+++ b/@stellar/design-system-website/src/types/types.d.ts
@@ -28,6 +28,7 @@ export enum ComponentDetailsId {
   statusBars = "statusBars",
   tables = "tables",
   tags = "tags",
+  textareas = "textareas",
   textLinks = "textLinks",
   toggles = "toggles",
   tooltips = "tooltips",
@@ -58,6 +59,7 @@ interface ComponentDetailsList {
   statusBars: ComponentDetails;
   tables: ComponentDetails;
   tags: ComponentDetails;
+  textareas: ComponentDetails;
   textLinks: ComponentDetails;
   toggles: ComponentDetails;
   tooltips: ComponentDetails;

--- a/@stellar/design-system/package.json
+++ b/@stellar/design-system/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/design-system",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "author": "Stellar Development Foundation <hello@stellar.org>",
   "description": "Components for Stellar Development Foundation’s design system",
   "license": "Apache-2.0",

--- a/@stellar/design-system/src/components/Checkbox/index.tsx
+++ b/@stellar/design-system/src/components/Checkbox/index.tsx
@@ -1,32 +1,45 @@
 import React from "react";
 import "./styles.scss";
+import { FieldNote } from "../utils/FieldNote";
 import { Icon } from "../../icons";
 
 interface CheckboxProps extends React.InputHTMLAttributes<HTMLInputElement> {
   id: string;
   label: string | React.ReactNode;
+  note?: string | React.ReactNode;
+  error?: string | React.ReactNode;
 }
 
 export const Checkbox: React.FC<CheckboxProps> = ({
   id,
   label,
+  note,
+  error,
   ...props
 }: CheckboxProps) => {
   const additionalClasses = [
     ...(props.disabled ? ["Checkbox--disabled"] : []),
+    ...(error ? ["Checkbox--error"] : []),
   ].join(" ");
 
   return (
     <div className={`Checkbox ${additionalClasses}`}>
-      <input type="checkbox" id={id} {...props} />
-      <label htmlFor={id}>
-        {label}
-        <span className="Checkbox__icon" aria-hidden="true">
-          <span>
-            <Icon.Check />
+      <div className="Checkbox__container">
+        <input type="checkbox" id={id} {...props} />
+        <label htmlFor={id}>
+          {label}
+          <span className="Checkbox__icon" aria-hidden="true">
+            <span>
+              <Icon.Check />
+            </span>
           </span>
-        </span>
-      </label>
+        </label>
+      </div>
+
+      {note && <FieldNote>{note}</FieldNote>}
+      {error && (
+        <FieldNote variant={FieldNote.variant.error}>{error}</FieldNote>
+      )}
     </div>
   );
 };

--- a/@stellar/design-system/src/components/Checkbox/styles.scss
+++ b/@stellar/design-system/src/components/Checkbox/styles.scss
@@ -1,18 +1,20 @@
 @use "../../mixins.scss";
 
 .Checkbox {
-  display: flex;
-  align-items: center;
-  position: relative;
+  &__container {
+    display: flex;
+    align-items: center;
+    position: relative;
 
-  @include mixins.checkbox-radio-base-selectors("checkbox");
+    @include mixins.checkbox-radio-base-selectors("checkbox");
 
-  label {
-    @include mixins.checkbox-radio-label;
+    label {
+      @include mixins.checkbox-radio-label;
 
-    &::before {
-      @include mixins.checkbox-radio-container;
-      border-radius: 0.25rem;
+      &::before {
+        @include mixins.checkbox-radio-container;
+        border-radius: 0.25rem;
+      }
     }
   }
 
@@ -29,6 +31,12 @@
       @include mixins.svg-color(var(--pal-brand-primary-on));
       width: var(--checkbox-selected-size);
       height: var(--checkbox-selected-size);
+    }
+  }
+
+  &--error {
+    label::before {
+      border-color: var(--pal-error);
     }
   }
 

--- a/@stellar/design-system/src/components/CopyText/index.tsx
+++ b/@stellar/design-system/src/components/CopyText/index.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from "react";
 import CopyToClipboard from "react-copy-to-clipboard";
 import { Tooltip, TooltipPosition } from "../Tooltip";
-import { Icon } from "../../icons";
 import "./styles.scss";
 
 interface CopyTextComponent {
@@ -10,7 +9,6 @@ interface CopyTextComponent {
 
 interface CopyTextProps {
   textToCopy: string;
-  showCopyIcon?: boolean;
   showTooltip?: boolean;
   doneLabel?: string;
   tooltipPosition?: TooltipPosition;
@@ -20,7 +18,6 @@ interface CopyTextProps {
 
 export const CopyText: React.FC<CopyTextProps> & CopyTextComponent = ({
   textToCopy,
-  showCopyIcon,
   showTooltip,
   doneLabel = "Copied",
   tooltipPosition = TooltipPosition.BOTTOM,
@@ -67,12 +64,6 @@ export const CopyText: React.FC<CopyTextProps> & CopyTextComponent = ({
         <CopyToClipboard text={textToCopy} onCopy={handleCopyDone}>
           <div title={title} role="button" className="CopyText__content">
             {renderElement(children)}
-
-            {showCopyIcon ? (
-              <div className="CopyText__content__copy-icon">
-                <Icon.Copy />
-              </div>
-            ) : null}
           </div>
         </CopyToClipboard>
       </Tooltip>

--- a/@stellar/design-system/src/components/CopyText/styles.scss
+++ b/@stellar/design-system/src/components/CopyText/styles.scss
@@ -7,25 +7,5 @@
     transition: opacity var(--anim-transition-default);
     display: inline-flex;
     align-items: center;
-
-    &__copy-icon {
-      --CopyIcon-size: 1.25rem;
-
-      width: var(--CopyIcon-size);
-      height: var(--CopyIcon-size);
-      margin-left: 0.5rem;
-
-      svg {
-        width: 100%;
-        height: 100%;
-        stroke: var(--pal-text-link);
-      }
-    }
-
-    @media (hover: hover) {
-      &:hover {
-        opacity: var(--opacity-disabled-button);
-      }
-    }
   }
 }

--- a/@stellar/design-system/src/components/IconButton/index.tsx
+++ b/@stellar/design-system/src/components/IconButton/index.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Icon } from "../../icons";
 import "./styles.scss";
 
 enum IconButtonVariant {
@@ -9,23 +10,57 @@ enum IconButtonVariant {
   highlight = "highlight",
 }
 
-interface IconButtonComponent {
-  variant: typeof IconButtonVariant;
+enum IconButtonPreset {
+  copy = "copy",
+  download = "download",
 }
 
-interface IconButtonProps
+interface IconButtonComponent {
+  variant: typeof IconButtonVariant;
+  preset: typeof IconButtonPreset;
+}
+
+interface IconButtonBaseProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-  icon: React.ReactNode;
-  altText: string;
   variant?: IconButtonVariant;
+  label?: string;
   customColor?: string;
   customSize?: string;
 }
 
+interface IconButtonDefaultProps extends IconButtonBaseProps {
+  icon: React.ReactNode;
+  altText: string;
+  preset?: IconButtonPreset;
+}
+
+interface IconButtonPresetProps extends IconButtonBaseProps {
+  preset: IconButtonPreset;
+  icon?: React.ReactNode;
+  altText?: string;
+}
+
+type IconButtonProps = IconButtonDefaultProps | IconButtonPresetProps;
+
+const presetDetails = {
+  [IconButtonPreset.copy]: {
+    label: "Copy",
+    altText: "Copy",
+    icon: <Icon.Copy />,
+  },
+  [IconButtonPreset.download]: {
+    label: "Download",
+    altText: "Download",
+    icon: <Icon.Download />,
+  },
+};
+
 export const IconButton: React.FC<IconButtonProps> & IconButtonComponent = ({
   icon,
   altText,
+  label,
   variant = IconButtonVariant.default,
+  preset,
   customColor,
   customSize,
   ...props
@@ -35,17 +70,38 @@ export const IconButton: React.FC<IconButtonProps> & IconButtonComponent = ({
     ...(customSize ? { "--IconButton-size": customSize } : {}),
   } as React.CSSProperties;
 
+  const renderContent = () => {
+    if (preset) {
+      return (
+        <>
+          <span className="IconButton__label">
+            {label ?? presetDetails[preset].label}
+          </span>
+          {presetDetails[preset].icon}
+        </>
+      );
+    }
+
+    return (
+      <>
+        {label ? <span className="IconButton__label">{label}</span> : null}
+        {icon}
+      </>
+    );
+  };
+
   return (
     <button
       className={`IconButton IconButton--${variant}`}
-      title={altText}
+      title={preset ? presetDetails[preset].altText : altText}
       {...props}
       style={customStyle}
     >
-      {icon}
+      {renderContent()}
     </button>
   );
 };
 
 IconButton.displayName = "IconButton";
 IconButton.variant = IconButtonVariant;
+IconButton.preset = IconButtonPreset;

--- a/@stellar/design-system/src/components/IconButton/styles.scss
+++ b/@stellar/design-system/src/components/IconButton/styles.scss
@@ -4,7 +4,6 @@
   --IconButton-size: 1.25rem;
 
   cursor: pointer;
-  width: var(--IconButton-size);
   height: var(--IconButton-size);
   flex-shrink: 0;
   border: none;
@@ -18,9 +17,16 @@
   transition: opacity var(--anim-transition-default);
 
   svg {
-    width: 100%;
-    height: 100%;
+    width: var(--IconButton-size);
+    height: var(--IconButton-size);
     @include mixins.svg-color(var(--IconButton-color));
+  }
+
+  &__label {
+    color: var(--IconButton-color);
+    margin-right: 0.5rem;
+    font-weight: var(--font-weight-medium);
+    font-size: max(1rem, calc(var(--IconButton-size) * 0.75));
   }
 
   &--default {

--- a/@stellar/design-system/src/components/Table/index.tsx
+++ b/@stellar/design-system/src/components/Table/index.tsx
@@ -19,6 +19,7 @@ interface TableProps<T> {
   data: T[];
   columnLabels: TableColumnLabel[];
   renderItemRow: (item: T) => React.ReactElement;
+  breakpoint: 300 | 400 | 500 | 600 | 700 | 800 | 900;
   hideNumberColumn?: boolean;
   isLoading?: boolean;
   emptyMessage?: string;
@@ -30,6 +31,7 @@ export const Table = <T extends Record<string, any>>({
   data,
   columnLabels,
   renderItemRow,
+  breakpoint,
   hideNumberColumn,
   isLoading,
   emptyMessage = "No data to show",
@@ -115,6 +117,7 @@ export const Table = <T extends Record<string, any>>({
             className={["Table", isSortableTable ? "SortableTable" : ""].join(
               " ",
             )}
+            data-breakpoint={breakpoint}
           >
             <thead>
               <tr>

--- a/@stellar/design-system/src/components/Table/styles.scss
+++ b/@stellar/design-system/src/components/Table/styles.scss
@@ -22,15 +22,39 @@
   overflow-x: auto;
 }
 
-table.Table {
-  --table-min-width: 900px;
+@mixin tableBreakpoint($bp) {
+  &[data-breakpoint="#{$bp}"] {
+    min-width: #{$bp}px;
 
+    th {
+      @media (min-width: #{$bp}px) {
+        padding-top: 0;
+      }
+    }
+
+    th:first-child,
+    td:first-child {
+      @media (max-width: #{$bp}px) {
+        // Sticky first column
+        &:not(:last-child) {
+          background-color: var(--pal-background-secondary);
+          left: 0;
+          position: sticky;
+          padding-left: 1rem;
+          box-shadow: 0 0 0.5rem rgba(var(--pal-shadow-rbg), 0.48);
+          clip-path: inset(0 -0.5rem 0 0);
+        }
+      }
+    }
+  }
+}
+
+table.Table {
   width: 100%;
   border-collapse: collapse;
   font-size: var(--font-size-secondary);
   line-height: 1.5rem;
   color: var(--pal-text-primary);
-  min-width: var(--table-min-width);
   color: var(--pal-text-secondary);
 
   th {
@@ -41,10 +65,6 @@ table.Table {
     text-align: left;
     padding-top: 1.0625rem;
     padding-bottom: 1.0625rem;
-
-    @media (min-width: 900px) {
-      padding-top: 0;
-    }
   }
 
   thead,
@@ -66,19 +86,15 @@ table.Table {
   th:first-child,
   td:first-child {
     padding-left: 0;
-
-    @media (max-width: 900px) {
-      // Sticky first column
-      &:not(:last-child) {
-        background-color: var(--pal-background-secondary);
-        left: 0;
-        position: sticky;
-        padding-left: 1rem;
-        box-shadow: 0 0 0.5rem rgba(var(--pal-shadow-rbg), 0.48);
-        clip-path: inset(0 -0.5rem 0 0);
-      }
-    }
   }
+
+  @include tableBreakpoint(900);
+  @include tableBreakpoint(800);
+  @include tableBreakpoint(700);
+  @include tableBreakpoint(600);
+  @include tableBreakpoint(500);
+  @include tableBreakpoint(400);
+  @include tableBreakpoint(300);
 
   td {
     padding-top: 1rem;

--- a/@stellar/design-system/src/components/Textarea/index.tsx
+++ b/@stellar/design-system/src/components/Textarea/index.tsx
@@ -1,0 +1,58 @@
+import React, { cloneElement } from "react";
+import { FieldNote } from "../utils/FieldNote";
+import "./styles.scss";
+
+interface TextareaProps
+  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {
+  id: string;
+  children?: string;
+  label?: string | React.ReactNode;
+  note?: string | React.ReactNode;
+  error?: string | React.ReactNode;
+  customTextarea?: React.ReactElement;
+}
+
+export const Textarea: React.FC<TextareaProps> = ({
+  id,
+  children = "",
+  label,
+  note,
+  error,
+  customTextarea,
+  spellCheck = false,
+  autoComplete = "off",
+  ...props
+}: TextareaProps) => {
+  const additionalClasses = [
+    ...(props.disabled ? ["Textarea--disabled"] : []),
+    ...(error ? ["Textarea--error"] : []),
+  ].join(" ");
+
+  const baseTextareaProps = {
+    id,
+    "aria-invalid": !!error,
+  };
+
+  return (
+    <div className={`Textarea ${additionalClasses}`}>
+      {label && <label htmlFor={id}>{label}</label>}
+
+      <div className="Textarea__wrapper">
+        {customTextarea ? (
+          cloneElement(customTextarea, { ...baseTextareaProps, ...props })
+        ) : (
+          <textarea {...baseTextareaProps} {...props}>
+            {children}
+          </textarea>
+        )}
+      </div>
+
+      {note && <FieldNote>{note}</FieldNote>}
+      {error && (
+        <FieldNote variant={FieldNote.variant.error}>{error}</FieldNote>
+      )}
+    </div>
+  );
+};
+
+Textarea.displayName = "Textarea";

--- a/@stellar/design-system/src/components/Textarea/styles.scss
+++ b/@stellar/design-system/src/components/Textarea/styles.scss
@@ -1,0 +1,38 @@
+@use "../../mixins.scss";
+
+.Textarea {
+  width: 100%;
+
+  &__wrapper {
+    @include mixins.form-field-container;
+    @include mixins.form-field-wrapper;
+    flex: 1;
+    height: 100%;
+
+    @media (hover: hover) {
+      &:hover {
+        @include mixins.form-field-wrapper-hover;
+      }
+    }
+
+    textarea {
+      @include mixins.form-field-base;
+      @include mixins.form-field-focus;
+      resize: none;
+
+      &::placeholder {
+        color: var(--pal-text-tertiary);
+      }
+
+      @include mixins.form-field-disabled;
+    }
+  }
+
+  &--error {
+    @include mixins.form-field-wrapper-error(".Textarea__wrapper");
+  }
+
+  &--disabled {
+    @include mixins.form-field-wrapper-disabled(".Textarea__wrapper");
+  }
+}

--- a/@stellar/design-system/src/components/index.ts
+++ b/@stellar/design-system/src/components/index.ts
@@ -21,6 +21,7 @@ export * from "./Select";
 export * from "./StatusBar";
 export * from "./Table";
 export * from "./Tag";
+export * from "./Textarea";
 export * from "./TextLink";
 export * from "./Toggle";
 export * from "./Tooltip";


### PR DESCRIPTION
**Breaking changes**
- Table requires a `breakpoint` property, which is used to trigger the sticky column layout.
- `CopyText` property `showCopyIcon` was removed, now you need to pass `IconButton` copy preset as `children` to achieve the same result.

**Updates**
- `IconButton` has new properties: `label` and `preset`.
- `Checkbox` has new properties: `note` and `error`.
- `Toggle` component has an example of how to use it with form labels.
- New `Textarea` component.

**Internal**
- Updated GitHub Action to update dependencies.
