### PR TITLE
Table: add breakpoint

### DIFF
--- a/@stellar/design-system-website/src/components/Details/styles.scss
+++ b/@stellar/design-system-website/src/components/Details/styles.scss
@@ -35,10 +35,6 @@
       justify-content: flex-start;
       align-items: center;
       flex-wrap: wrap;
-
-      .TableContainer .Table {
-        --table-min-width: 400px;
-      }
     }
 
     &__code {

--- a/@stellar/design-system-website/src/constants/details/tables.tsx
+++ b/@stellar/design-system-website/src/constants/details/tables.tsx
@@ -84,6 +84,7 @@ export const tables: ComponentDetails = {
           data={tableData}
           renderItemRow={renderItemRow}
           hideNumberColumn
+          breakpoint={400}
         />,
       ],
     },
@@ -96,6 +97,7 @@ export const tables: ComponentDetails = {
           data={tableData}
           renderItemRow={renderItemRow}
           pageSize={2}
+          breakpoint={400}
         />,
       ],
     },
@@ -108,6 +110,7 @@ export const tables: ComponentDetails = {
           data={tableData}
           renderItemRow={renderItemRow}
           pageSize={2}
+          breakpoint={400}
           isLoading
         />,
       ],
@@ -120,6 +123,7 @@ export const tables: ComponentDetails = {
           columnLabels={sortableTableLabels}
           data={[]}
           renderItemRow={renderItemRow}
+          breakpoint={400}
         />,
       ],
     },
@@ -152,6 +156,13 @@ export const tables: ComponentDetails = {
       default: null,
       optional: false,
       description: "Function to render table rows",
+    },
+    {
+      prop: "breakpoint",
+      type: ["300", "400", "500", "600", "700", "800", "900"],
+      default: null,
+      optional: false,
+      description: "Media query breakpoint to show sticky column layout",
     },
     {
       prop: "hideNumberColumn",

--- a/@stellar/design-system-website/src/generated/gitInfo.ts
+++ b/@stellar/design-system-website/src/generated/gitInfo.ts
@@ -1,1 +1,1 @@
-export default { commitHash: "2b4efff" };
+export default { commitHash: "46f21dc" };

--- a/@stellar/design-system/src/components/Table/index.tsx
+++ b/@stellar/design-system/src/components/Table/index.tsx
@@ -19,6 +19,7 @@ interface TableProps<T> {
   data: T[];
   columnLabels: TableColumnLabel[];
   renderItemRow: (item: T) => React.ReactElement;
+  breakpoint: 300 | 400 | 500 | 600 | 700 | 800 | 900;
   hideNumberColumn?: boolean;
   isLoading?: boolean;
   emptyMessage?: string;
@@ -30,6 +31,7 @@ export const Table = <T extends Record<string, any>>({
   data,
   columnLabels,
   renderItemRow,
+  breakpoint,
   hideNumberColumn,
   isLoading,
   emptyMessage = "No data to show",
@@ -115,6 +117,7 @@ export const Table = <T extends Record<string, any>>({
             className={["Table", isSortableTable ? "SortableTable" : ""].join(
               " ",
             )}
+            data-breakpoint={breakpoint}
           >
             <thead>
               <tr>

--- a/@stellar/design-system/src/components/Table/styles.scss
+++ b/@stellar/design-system/src/components/Table/styles.scss
@@ -22,15 +22,39 @@
   overflow-x: auto;
 }
 
-table.Table {
-  --table-min-width: 900px;
+@mixin tableBreakpoint($bp) {
+  &[data-breakpoint="#{$bp}"] {
+    min-width: #{$bp}px;
 
+    th {
+      @media (min-width: #{$bp}px) {
+        padding-top: 0;
+      }
+    }
+
+    th:first-child,
+    td:first-child {
+      @media (max-width: #{$bp}px) {
+        // Sticky first column
+        &:not(:last-child) {
+          background-color: var(--pal-background-secondary);
+          left: 0;
+          position: sticky;
+          padding-left: 1rem;
+          box-shadow: 0 0 0.5rem rgba(var(--pal-shadow-rbg), 0.48);
+          clip-path: inset(0 -0.5rem 0 0);
+        }
+      }
+    }
+  }
+}
+
+table.Table {
   width: 100%;
   border-collapse: collapse;
   font-size: var(--font-size-secondary);
   line-height: 1.5rem;
   color: var(--pal-text-primary);
-  min-width: var(--table-min-width);
   color: var(--pal-text-secondary);
 
   th {
@@ -41,10 +65,6 @@ table.Table {
     text-align: left;
     padding-top: 1.0625rem;
     padding-bottom: 1.0625rem;
-
-    @media (min-width: 900px) {
-      padding-top: 0;
-    }
   }
 
   thead,
@@ -66,19 +86,15 @@ table.Table {
   th:first-child,
   td:first-child {
     padding-left: 0;
-
-    @media (max-width: 900px) {
-      // Sticky first column
-      &:not(:last-child) {
-        background-color: var(--pal-background-secondary);
-        left: 0;
-        position: sticky;
-        padding-left: 1rem;
-        box-shadow: 0 0 0.5rem rgba(var(--pal-shadow-rbg), 0.48);
-        clip-path: inset(0 -0.5rem 0 0);
-      }
-    }
   }
+
+  @include tableBreakpoint(900);
+  @include tableBreakpoint(800);
+  @include tableBreakpoint(700);
+  @include tableBreakpoint(600);
+  @include tableBreakpoint(500);
+  @include tableBreakpoint(400);
+  @include tableBreakpoint(300);
 
   td {
     padding-top: 1rem;


### PR DESCRIPTION
Breaking change:
- Table requires prop `breakpoint`, used to trigger the sticky column layout.