### PR TITLE
IconButton + CopyText updates

### DIFF
--- a/@stellar/design-system-website/src/constants/details/copyTexts.tsx
+++ b/@stellar/design-system-website/src/constants/details/copyTexts.tsx
@@ -1,4 +1,4 @@
-import { CopyText, TextLink } from "@stellar/design-system";
+import { CopyText, TextLink, IconButton } from "@stellar/design-system";
 import { ComponentDetails, ComponentDetailsId } from "types/types.d";
 
 export const copyTexts: ComponentDetails = {
@@ -32,16 +32,18 @@ export const copyTexts: ComponentDetails = {
       ],
     },
     {
-      title: "With copy icon",
+      title: "Using Icon button copy preset",
       description: "Text link with copy icon and tooltip",
       component: [
         <CopyText
           textToCopy="Test copy"
-          showCopyIcon
           showTooltip
           tooltipPosition={CopyText.tooltipPosition.RIGHT}
         >
-          <TextLink>Copy</TextLink>
+          <IconButton
+            preset={IconButton.preset.copy}
+            variant={IconButton.variant.highlight}
+          />
         </CopyText>,
       ],
     },
@@ -53,13 +55,6 @@ export const copyTexts: ComponentDetails = {
       default: null,
       optional: false,
       description: "Text to copy",
-    },
-    {
-      prop: "showCopyIcon",
-      type: ["boolean"],
-      default: null,
-      optional: true,
-      description: "Flag to enable copy icon",
     },
     {
       prop: "showTooltip",

--- a/@stellar/design-system-website/src/constants/details/iconButtons.tsx
+++ b/@stellar/design-system-website/src/constants/details/iconButtons.tsx
@@ -9,7 +9,8 @@ export const iconButtons: ComponentDetails = {
       <code>IconButton</code> is similar to the <code>Button</code>, and is used
       to trigger an action. There are five variants (color is the only
       difference): <code>default</code>, <code>error</code>,{" "}
-      <code>success</code>, <code>warning</code>, <code>highlight</code>.
+      <code>success</code>, <code>warning</code>, <code>highlight</code>; and
+      two presets: <code>copy</code> and <code>download</code>.
     </>
   ),
   shortDescription: "Similar to the Button, and is used to trigger an action",
@@ -20,6 +21,19 @@ export const iconButtons: ComponentDetails = {
       component: [
         <IconButton icon={<Icon.Info />} altText="Default" />,
         <IconButton icon={<Icon.Info />} altText="Default" disabled />,
+      ],
+    },
+    {
+      title: "Default with label",
+      description: "",
+      component: [
+        <IconButton icon={<Icon.Info />} label="Default" altText="Default" />,
+        <IconButton
+          icon={<Icon.Info />}
+          label="Default"
+          altText="Default"
+          disabled
+        />,
       ],
     },
     {
@@ -91,6 +105,36 @@ export const iconButtons: ComponentDetails = {
       ],
     },
     {
+      title: "Preset: copy",
+      description: "",
+      component: [
+        <IconButton
+          preset={IconButton.preset.copy}
+          variant={IconButton.variant.highlight}
+        />,
+        <IconButton
+          preset={IconButton.preset.copy}
+          variant={IconButton.variant.highlight}
+          disabled
+        />,
+      ],
+    },
+    {
+      title: "Preset: download",
+      description: "",
+      component: [
+        <IconButton
+          preset={IconButton.preset.download}
+          variant={IconButton.variant.highlight}
+        />,
+        <IconButton
+          preset={IconButton.preset.download}
+          variant={IconButton.variant.highlight}
+          disabled
+        />,
+      ],
+    },
+    {
       title: "Custom color",
       description: "",
       component: [
@@ -124,8 +168,34 @@ export const iconButtons: ComponentDetails = {
         />,
       ],
     },
+    {
+      title: "Custom size with label",
+      description: "",
+      component: [
+        <IconButton
+          icon={<Icon.Info />}
+          altText="Custom size"
+          label="Custom"
+          customSize="2rem"
+        />,
+        <IconButton
+          icon={<Icon.Info />}
+          altText="Custom size"
+          label="Custom"
+          customSize="2rem"
+          disabled
+        />,
+      ],
+    },
   ],
   props: [
+    {
+      prop: "IconButtonDefaultProps",
+      type: [],
+      default: null,
+      optional: false,
+      description: "",
+    },
     {
       prop: "icon",
       type: ["ReactNode"],
@@ -141,11 +211,39 @@ export const iconButtons: ComponentDetails = {
       description: "Alternative text to show on hover",
     },
     {
+      prop: "IconButtonPresetProps",
+      type: [],
+      default: null,
+      optional: false,
+      description: "",
+    },
+    {
+      prop: "preset",
+      type: ["copy", "download"],
+      default: null,
+      optional: false,
+      description: "Predefined set of icon buttons",
+    },
+    {
+      prop: "IconButtonBaseProps",
+      type: [],
+      default: null,
+      optional: false,
+      description: "",
+    },
+    {
       prop: "variant",
       type: ["default", "error", "success", "warning", "highlight"],
       default: "default",
       optional: true,
       description: "Variant of the component",
+    },
+    {
+      prop: "label",
+      type: ["string"],
+      default: null,
+      optional: true,
+      description: "Component label",
     },
     {
       prop: "customColor",

--- a/@stellar/design-system-website/src/generated/gitInfo.ts
+++ b/@stellar/design-system-website/src/generated/gitInfo.ts
@@ -1,1 +1,1 @@
-export default { commitHash: "46f21dc" };
+export default { commitHash: "114d9cd" };

--- a/@stellar/design-system/src/components/CopyText/index.tsx
+++ b/@stellar/design-system/src/components/CopyText/index.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from "react";
 import CopyToClipboard from "react-copy-to-clipboard";
 import { Tooltip, TooltipPosition } from "../Tooltip";
-import { Icon } from "../../icons";
 import "./styles.scss";
 
 interface CopyTextComponent {
@@ -10,7 +9,6 @@ interface CopyTextComponent {
 
 interface CopyTextProps {
   textToCopy: string;
-  showCopyIcon?: boolean;
   showTooltip?: boolean;
   doneLabel?: string;
   tooltipPosition?: TooltipPosition;
@@ -20,7 +18,6 @@ interface CopyTextProps {
 
 export const CopyText: React.FC<CopyTextProps> & CopyTextComponent = ({
   textToCopy,
-  showCopyIcon,
   showTooltip,
   doneLabel = "Copied",
   tooltipPosition = TooltipPosition.BOTTOM,
@@ -67,12 +64,6 @@ export const CopyText: React.FC<CopyTextProps> & CopyTextComponent = ({
         <CopyToClipboard text={textToCopy} onCopy={handleCopyDone}>
           <div title={title} role="button" className="CopyText__content">
             {renderElement(children)}
-
-            {showCopyIcon ? (
-              <div className="CopyText__content__copy-icon">
-                <Icon.Copy />
-              </div>
-            ) : null}
           </div>
         </CopyToClipboard>
       </Tooltip>

--- a/@stellar/design-system/src/components/CopyText/styles.scss
+++ b/@stellar/design-system/src/components/CopyText/styles.scss
@@ -7,25 +7,5 @@
     transition: opacity var(--anim-transition-default);
     display: inline-flex;
     align-items: center;
-
-    &__copy-icon {
-      --CopyIcon-size: 1.25rem;
-
-      width: var(--CopyIcon-size);
-      height: var(--CopyIcon-size);
-      margin-left: 0.5rem;
-
-      svg {
-        width: 100%;
-        height: 100%;
-        stroke: var(--pal-text-link);
-      }
-    }
-
-    @media (hover: hover) {
-      &:hover {
-        opacity: var(--opacity-disabled-button);
-      }
-    }
   }
 }

--- a/@stellar/design-system/src/components/IconButton/index.tsx
+++ b/@stellar/design-system/src/components/IconButton/index.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Icon } from "../../icons";
 import "./styles.scss";
 
 enum IconButtonVariant {
@@ -9,23 +10,57 @@ enum IconButtonVariant {
   highlight = "highlight",
 }
 
-interface IconButtonComponent {
-  variant: typeof IconButtonVariant;
+enum IconButtonPreset {
+  copy = "copy",
+  download = "download",
 }
 
-interface IconButtonProps
+interface IconButtonComponent {
+  variant: typeof IconButtonVariant;
+  preset: typeof IconButtonPreset;
+}
+
+interface IconButtonBaseProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-  icon: React.ReactNode;
-  altText: string;
   variant?: IconButtonVariant;
+  label?: string;
   customColor?: string;
   customSize?: string;
 }
 
+interface IconButtonDefaultProps extends IconButtonBaseProps {
+  icon: React.ReactNode;
+  altText: string;
+  preset?: IconButtonPreset;
+}
+
+interface IconButtonPresetProps extends IconButtonBaseProps {
+  preset: IconButtonPreset;
+  icon?: React.ReactNode;
+  altText?: string;
+}
+
+type IconButtonProps = IconButtonDefaultProps | IconButtonPresetProps;
+
+const presetDetails = {
+  [IconButtonPreset.copy]: {
+    label: "Copy",
+    altText: "Copy",
+    icon: <Icon.Copy />,
+  },
+  [IconButtonPreset.download]: {
+    label: "Download",
+    altText: "Download",
+    icon: <Icon.Download />,
+  },
+};
+
 export const IconButton: React.FC<IconButtonProps> & IconButtonComponent = ({
   icon,
   altText,
+  label,
   variant = IconButtonVariant.default,
+  preset,
   customColor,
   customSize,
   ...props
@@ -35,17 +70,38 @@ export const IconButton: React.FC<IconButtonProps> & IconButtonComponent = ({
     ...(customSize ? { "--IconButton-size": customSize } : {}),
   } as React.CSSProperties;
 
+  const renderContent = () => {
+    if (preset) {
+      return (
+        <>
+          <span className="IconButton__label">
+            {label ?? presetDetails[preset].label}
+          </span>
+          {presetDetails[preset].icon}
+        </>
+      );
+    }
+
+    return (
+      <>
+        {label ? <span className="IconButton__label">{label}</span> : null}
+        {icon}
+      </>
+    );
+  };
+
   return (
     <button
       className={`IconButton IconButton--${variant}`}
-      title={altText}
+      title={preset ? presetDetails[preset].altText : altText}
       {...props}
       style={customStyle}
     >
-      {icon}
+      {renderContent()}
     </button>
   );
 };
 
 IconButton.displayName = "IconButton";
 IconButton.variant = IconButtonVariant;
+IconButton.preset = IconButtonPreset;

--- a/@stellar/design-system/src/components/IconButton/styles.scss
+++ b/@stellar/design-system/src/components/IconButton/styles.scss
@@ -4,7 +4,6 @@
   --IconButton-size: 1.25rem;
 
   cursor: pointer;
-  width: var(--IconButton-size);
   height: var(--IconButton-size);
   flex-shrink: 0;
   border: none;
@@ -18,9 +17,16 @@
   transition: opacity var(--anim-transition-default);
 
   svg {
-    width: 100%;
-    height: 100%;
+    width: var(--IconButton-size);
+    height: var(--IconButton-size);
     @include mixins.svg-color(var(--IconButton-color));
+  }
+
+  &__label {
+    color: var(--IconButton-color);
+    margin-right: 0.5rem;
+    font-weight: var(--font-weight-medium);
+    font-size: max(1rem, calc(var(--IconButton-size) * 0.75));
   }
 
   &--default {


### PR DESCRIPTION
**Updates**:
- `IconButton` has new props: `label` and `preset`.

![image](https://user-images.githubusercontent.com/7346473/157097437-b8f27d7b-6f01-4346-ae8e-4af54b8f1dc0.png)

**Breaking changes**:
- `CopyText` prop `showCopyIcon` was removed, need to pass `IconButton` copy preset as children to achieve the same result.