### PR TITLE
Floater and tooltip color update and small fix

### DIFF
--- a/@stellar/design-system-website/src/constants/details/tooltips.tsx
+++ b/@stellar/design-system-website/src/constants/details/tooltips.tsx
@@ -20,6 +20,13 @@ export const tooltips: ComponentDetails = {
         <Tooltip isVisible={true} triggerEl={<>Tooltip trigger</>}>
           Lorem ipsum dolor sit
         </Tooltip>,
+        <Tooltip
+          isVisible={true}
+          triggerEl={<>Tooltip trigger no contrast</>}
+          isContrast={false}
+        >
+          Lorem ipsum dolor sit
+        </Tooltip>,
       ],
     },
     {
@@ -74,6 +81,13 @@ export const tooltips: ComponentDetails = {
       default: null,
       optional: true,
       description: "Manually show/hide tooltip",
+    },
+    {
+      prop: "isContrast",
+      type: ["boolean"],
+      default: "true",
+      optional: true,
+      description: "Use contrast theme color",
     },
   ],
   externalProps: {

--- a/@stellar/design-system-website/src/generated/gitInfo.ts
+++ b/@stellar/design-system-website/src/generated/gitInfo.ts
@@ -1,1 +1,1 @@
-export default { commitHash: "066e11b" };
+export default { commitHash: "65ce97b" };

--- a/@stellar/design-system/src/components/Floater/index.tsx
+++ b/@stellar/design-system/src/components/Floater/index.tsx
@@ -24,6 +24,7 @@ interface FloaterProps {
   offset?: number;
   padding?: number;
   hasActiveInsideClick?: boolean;
+  isContrast?: boolean;
 }
 
 export const Floater: React.FC<FloaterProps> = ({
@@ -34,13 +35,14 @@ export const Floater: React.FC<FloaterProps> = ({
   offset = 8,
   padding = 24,
   hasActiveInsideClick,
+  isContrast = true,
 }: FloaterProps) => {
   const parentRef = useRef<HTMLDivElement | null>(null);
   const floaterRef = useRef<HTMLDivElement | null>(null);
 
   const [isFloaterOpen, setIsFloaterOpen] = useState(Boolean(isVisible));
   // If components has manual visibility control, we don't want to add clicks
-  const isStatic = Boolean(isVisible);
+  const isStatic = isVisible !== undefined;
 
   const triggerClass = "trigger";
   const triggerActiveClass = "trigger--active";
@@ -136,6 +138,10 @@ export const Floater: React.FC<FloaterProps> = ({
     };
   }, [isFloaterOpen, handleClickOutside]);
 
+  const additionalClasses = [
+    ...(isContrast ? [] : [`Floater__content--light`]),
+  ].join(" ");
+
   return (
     <div className="Floater" ref={parentRef}>
       {isStatic
@@ -144,7 +150,7 @@ export const Floater: React.FC<FloaterProps> = ({
             // Add floater click action
             onClick: toggleFloater,
           })}
-      <div ref={floaterRef} className="Floater__content">
+      <div ref={floaterRef} className={`Floater__content ${additionalClasses}`}>
         {children}
       </div>
     </div>

--- a/@stellar/design-system/src/components/Floater/styles.scss
+++ b/@stellar/design-system/src/components/Floater/styles.scss
@@ -12,11 +12,17 @@
     top: calc(100% + pxToRem(8px));
     left: 50%;
     transform: translateX(-50%);
-    color: var(--color-gray-80);
-    background-color: var(--color-gray-00);
-    border: 1px solid var(--color-gray-30);
-    border-radius: pxToRem(4px);
+    color: var(--color-gray-00);
+    background-color: var(--color-gray-90);
+    border: 1px solid var(--color-gray-90);
+    border-radius: pxToRem(6px);
     box-shadow: 0px pxToRem(2px) pxToRem(4px) rgba(0, 0, 0, 0.08);
+
+    &--light {
+      color: var(--color-gray-80);
+      background-color: var(--color-gray-00);
+      border-color: var(--color-gray-30);
+    }
   }
 
   // Floater open/close

--- a/@stellar/design-system/src/components/Tooltip/index.tsx
+++ b/@stellar/design-system/src/components/Tooltip/index.tsx
@@ -6,6 +6,7 @@ interface TooltipProps {
   children: React.ReactNode;
   placement?: FloaterPlacement;
   isVisible?: boolean;
+  isContrast?: boolean;
 }
 
 export const Tooltip: React.FC<TooltipProps> = ({
@@ -13,9 +14,15 @@ export const Tooltip: React.FC<TooltipProps> = ({
   children,
   placement = "right",
   isVisible,
+  isContrast = true,
 }: TooltipProps) => {
   return (
-    <Floater placement={placement} triggerEl={triggerEl} isVisible={isVisible}>
+    <Floater
+      placement={placement}
+      triggerEl={triggerEl}
+      isVisible={isVisible}
+      isContrast={isContrast}
+    >
       <div className="Tooltip">{children}</div>
     </Floater>
   );

--- a/@stellar/design-system/src/components/Tooltip/styles.scss
+++ b/@stellar/design-system/src/components/Tooltip/styles.scss
@@ -1,7 +1,7 @@
 @use "../../utils.scss" as *;
 
 .Tooltip {
-  padding: pxToRem(12px);
+  padding: pxToRem(8px) pxToRem(12px);
   width: max-content;
   max-width: pxToRem(232px);
   font-size: pxToRem(12px);


### PR DESCRIPTION
- Use a contrasting color for Floaters and Tooltip by default, with an option to change it.
- Apply Floater fix from SDP.

![image](https://user-images.githubusercontent.com/7346473/233417452-ae316210-b050-4984-8bfa-e6a502556ea7.png)
