### PR TITLE
allows for optional title in ProjectLogo and Layout.Header

### DIFF
--- a/@stellar/design-system-website/src/generated/gitInfo.ts
+++ b/@stellar/design-system-website/src/generated/gitInfo.ts
@@ -1,1 +1,1 @@
-export default { commitHash: "1345794" };
+export default { commitHash: "da0de86" };

--- a/@stellar/design-system/src/components/Layout/index.tsx
+++ b/@stellar/design-system/src/components/Layout/index.tsx
@@ -46,6 +46,7 @@ interface HeaderProps {
   };
   contentCenter?: React.ReactElement;
   contentRight?: React.ReactElement;
+  showTitle?: boolean;
 }
 
 const stringToCamelcase = (str: string) =>
@@ -65,7 +66,12 @@ const Header: React.FC<HeaderProps> = ({
   menu,
   contentCenter,
   contentRight,
+  showTitle,
 }: HeaderProps) => {
+  // In order to be able to save unique settings per project in ToggleDarkMode,
+  // we need to require a projectTitle but in some cases we don't need to display it.
+  const _projectTitle = showTitle === true ? projectTitle : undefined;
+
   // Set default mode to light, if there is no theme toggle
   useEffect(() => {
     if (!hasDarkModeToggle) {
@@ -78,7 +84,7 @@ const Header: React.FC<HeaderProps> = ({
       <Layout.Inset>
         {/* Left */}
         <div className="Layout__header--left">
-          <ProjectLogo title={projectTitle} link={projectLink} />
+          <ProjectLogo title={_projectTitle} link={projectLink} />
         </div>
 
         {/* Center */}

--- a/@stellar/design-system/src/components/ProjectLogo/index.tsx
+++ b/@stellar/design-system/src/components/ProjectLogo/index.tsx
@@ -3,7 +3,7 @@ import "./styles.scss";
 import { Logo } from "../../logos";
 
 interface ProjectLogoProps {
-  title: string;
+  title?: string;
   link?: string;
 }
 
@@ -15,7 +15,7 @@ export const ProjectLogo: React.FC<ProjectLogoProps> = ({
     <a href={link} rel="noreferrer noopener">
       <Logo.Stellar />
     </a>
-    <div className="ProjectLogo__title">{title}</div>
+    {title && <div className="ProjectLogo__title">{title}</div>}
   </div>
 );
 


### PR DESCRIPTION
There is some work for soroban example dapps where [the design ](https://www.figma.com/file/m0eIOUlee2EHBgHGhxQT6S/Soroban-Demos?type=design&node-id=2-12&t=5ZH3r5Nm4JgdrliS-0)has no title in the project logo component.

This makes the `title` in project logo optional.
This adds a `showTitle` prop in order to toggle the project title value that we pass to `ProjectLogo`. I'd like to just take an optional `projectTitle` also in `Layout.Header` but we need a unique string per project to support the `ToggleDarkMode` functionality. Is there a better way to do this?