### PR TITLE
Optional title for ProjectLogo and Layout.Header

### DIFF
--- a/@stellar/design-system-website/src/App.tsx
+++ b/@stellar/design-system-website/src/App.tsx
@@ -81,6 +81,7 @@ export const App = () => {
   return (
     <SideNavContext.Provider value={sideNavStateValue}>
       <Layout.Header
+        projectId="Design System"
         projectTitle="Design System"
         hasThemeSwitch
         menu={{

--- a/@stellar/design-system-website/src/constants/details/layout.tsx
+++ b/@stellar/design-system-website/src/constants/details/layout.tsx
@@ -17,7 +17,11 @@ export const layout: ComponentDetails = {
       title: "Default header",
       description: "",
       component: [
-        <Layout.Header projectTitle="Design System" hasThemeSwitch />,
+        <Layout.Header
+          projectId="Design System"
+          projectTitle="Design System"
+          hasThemeSwitch
+        />,
       ],
     },
     {

--- a/@stellar/design-system/src/components/Layout/index.tsx
+++ b/@stellar/design-system/src/components/Layout/index.tsx
@@ -34,7 +34,8 @@ const Content: React.FC<ContentProps> = ({ children }: ContentProps) => (
 );
 
 interface HeaderProps {
-  projectTitle: string;
+  projectId: string;
+  projectTitle?: string;
   projectLink?: string;
   hasThemeSwitch?: boolean;
   onThemeSwitchActionEnd?: (isDarkMode: boolean) => void;
@@ -56,6 +57,7 @@ const stringToCamelcase = (str: string) =>
     .replace(/\s+/g, "");
 
 const Header: React.FC<HeaderProps> = ({
+  projectId,
   projectTitle,
   projectLink,
   hasThemeSwitch,
@@ -98,7 +100,7 @@ const Header: React.FC<HeaderProps> = ({
 
           {hasThemeSwitch ? (
             <ThemeSwitch
-              storageKeyId={`stellarTheme:${stringToCamelcase(projectTitle)}`}
+              storageKeyId={`stellarTheme:${stringToCamelcase(projectId)}`}
               onActionEnd={onThemeSwitchActionEnd}
             />
           ) : null}

--- a/@stellar/design-system/src/components/ProjectLogo/index.tsx
+++ b/@stellar/design-system/src/components/ProjectLogo/index.tsx
@@ -3,7 +3,7 @@ import "./styles.scss";
 import { Logo } from "../../logos";
 
 interface ProjectLogoProps {
-  title: string;
+  title?: string;
   link?: string;
 }
 
@@ -15,7 +15,7 @@ export const ProjectLogo: React.FC<ProjectLogoProps> = ({
     <a href={link} rel="noreferrer noopener">
       <Logo.Stellar />
     </a>
-    <div className="ProjectLogo__title">{title}</div>
+    {title && <div className="ProjectLogo__title">{title}</div>}
   </div>
 );
 


### PR DESCRIPTION
Makes the projectTitle optional to support this design: https://www.figma.com/file/m0eIOUlee2EHBgHGhxQT6S/Soroban-Demos?type=design&node-id=2-12&t=5ZH3r5Nm4JgdrliS-0

Adds a new `projectId` prop in the Layout.Header in order to retain the functionality for `ToggleDarkMode`.