### PR TITLE
rename classNames prop to addlClassName

### DIFF
--- a/@stellar/design-system/src/components/Typography/index.tsx
+++ b/@stellar/design-system/src/components/Typography/index.tsx
@@ -5,7 +5,7 @@ import "./styles.scss";
 // =============================================================================
 interface HeadingProps extends React.HtmlHTMLAttributes<HTMLHeadingElement> {
   as: "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
-  addlClasses?: string;
+  addlClassName?: string;
   size: "xxl" | "xl" | "lg" | "md" | "sm" | "xs";
   children: string | React.ReactNode;
 }
@@ -17,7 +17,7 @@ export const Heading = ({
   ...props
 }: HeadingProps): JSX.Element => (
   <HtmlTag
-    className={`Heading Heading--${size} ${props.addlClasses || ""}`}
+    className={`Heading Heading--${size} ${props.addlClassName || ""}`}
     {...props}
   >
     {children}
@@ -31,7 +31,7 @@ Heading.displayName = "Heading";
 // =============================================================================
 interface CaptionProps extends React.HtmlHTMLAttributes<HTMLDivElement> {
   size: "lg" | "md" | "sm" | "xs";
-  addlClasses?: string;
+  addlClassName?: string;
   children: string | React.ReactNode;
 }
 
@@ -41,7 +41,7 @@ export const Caption = ({
   ...props
 }: CaptionProps): JSX.Element => (
   <div
-    className={`Caption Caption--${size} ${props.addlClasses || ""}`}
+    className={`Caption Caption--${size} ${props.addlClassName || ""}`}
     {...props}
   >
     {children}
@@ -55,7 +55,7 @@ Caption.displayName = "Caption";
 // =============================================================================
 interface ParagraphProps
   extends React.HtmlHTMLAttributes<HTMLParagraphElement | HTMLDivElement> {
-  addlClasses?: string;
+  addlClassName?: string;
   size: "lg" | "md" | "sm" | "xs";
   children: string | React.ReactNode;
   asDiv?: boolean;
@@ -71,7 +71,7 @@ export const Paragraph = ({
 
   return (
     <HtmlTag
-      className={`Paragraph Paragraph--${size} ${props.addlClasses || ""}`}
+      className={`Paragraph Paragraph--${size} ${props.addlClassName || ""}`}
       {...props}
     >
       {children}
@@ -85,7 +85,7 @@ Paragraph.displayName = "Paragraph";
 // Title
 // =============================================================================
 interface TitleProps extends React.HtmlHTMLAttributes<HTMLDivElement> {
-  addlClasses?: string;
+  addlClassName?: string;
   size: "lg" | "md" | "sm" | "xs";
   children: string | React.ReactNode;
 }
@@ -95,7 +95,10 @@ export const Title = ({
   children,
   ...props
 }: TitleProps): JSX.Element => (
-  <div className={`Title Title--${size} ${props.addlClasses || ""}`} {...props}>
+  <div
+    className={`Title Title--${size} ${props.addlClassName || ""}`}
+    {...props}
+  >
     {children}
   </div>
 );

--- a/@stellar/design-system/src/components/Typography/index.tsx
+++ b/@stellar/design-system/src/components/Typography/index.tsx
@@ -5,6 +5,7 @@ import "./styles.scss";
 // =============================================================================
 interface HeadingProps extends React.HtmlHTMLAttributes<HTMLHeadingElement> {
   as: "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
+  addlClasses?: string;
   size: "xxl" | "xl" | "lg" | "md" | "sm" | "xs";
   children: string | React.ReactNode;
 }
@@ -16,7 +17,7 @@ export const Heading = ({
   ...props
 }: HeadingProps): JSX.Element => (
   <HtmlTag
-    className={`Heading Heading--${size} ${props.className || ""}`}
+    className={`Heading Heading--${size} ${props.addlClasses || ""}`}
     {...props}
   >
     {children}
@@ -30,6 +31,7 @@ Heading.displayName = "Heading";
 // =============================================================================
 interface CaptionProps extends React.HtmlHTMLAttributes<HTMLDivElement> {
   size: "lg" | "md" | "sm" | "xs";
+  addlClasses?: string;
   children: string | React.ReactNode;
 }
 
@@ -39,7 +41,7 @@ export const Caption = ({
   ...props
 }: CaptionProps): JSX.Element => (
   <div
-    className={`Caption Caption--${size} ${props.className || ""}`}
+    className={`Caption Caption--${size} ${props.addlClasses || ""}`}
     {...props}
   >
     {children}
@@ -53,6 +55,7 @@ Caption.displayName = "Caption";
 // =============================================================================
 interface ParagraphProps
   extends React.HtmlHTMLAttributes<HTMLParagraphElement | HTMLDivElement> {
+  addlClasses?: string;
   size: "lg" | "md" | "sm" | "xs";
   children: string | React.ReactNode;
   asDiv?: boolean;
@@ -68,7 +71,7 @@ export const Paragraph = ({
 
   return (
     <HtmlTag
-      className={`Paragraph Paragraph--${size} ${props.className || ""}`}
+      className={`Paragraph Paragraph--${size} ${props.addlClasses || ""}`}
       {...props}
     >
       {children}
@@ -82,6 +85,7 @@ Paragraph.displayName = "Paragraph";
 // Title
 // =============================================================================
 interface TitleProps extends React.HtmlHTMLAttributes<HTMLDivElement> {
+  addlClasses?: string;
   size: "lg" | "md" | "sm" | "xs";
   children: string | React.ReactNode;
 }
@@ -91,7 +95,7 @@ export const Title = ({
   children,
   ...props
 }: TitleProps): JSX.Element => (
-  <div className={`Title Title--${size} ${props.className || ""}`} {...props}>
+  <div className={`Title Title--${size} ${props.addlClasses || ""}`} {...props}>
     {children}
   </div>
 );


### PR DESCRIPTION
Right now in Typography, each component can take a `className` prop to add new classes to the base set.
If you try to pass a prop named `className` to a React component, it will treat it as the built in `className` property and will override the classes that come with the component initially.

Example - 
```
 <Caption size="xs" className="step-count">
    ...
 </Caption>
```

will result in

```
<div class="step-count">...</div>
```
and will be missing the original classes for the component, should end up being this

```
<div class="Caption Caption--xs step-count">...</div>
```

We can rename the class used to add more classes to the components class list in order to avoid this.