### PR TITLE
picks out addlClassName from props before spreading onto dom nodes

### DIFF
--- a/@stellar/design-system-website/src/constants/details/typography.tsx
+++ b/@stellar/design-system-website/src/constants/details/typography.tsx
@@ -110,6 +110,13 @@ export const typography: ComponentDetails = {
       description: "",
     },
     {
+      prop: "addlClassName",
+      type: ["string"],
+      default: null,
+      optional: true,
+      description: "Additional classes",
+    },
+    {
       prop: "as",
       type: ["h1", "h2", "h3", "h4", "h5", "h6"],
       default: null,
@@ -140,6 +147,13 @@ export const typography: ComponentDetails = {
       description: "",
     },
     {
+      prop: "addlClassName",
+      type: ["string"],
+      default: null,
+      optional: true,
+      description: "Additional classes",
+    },
+    {
       prop: "size",
       type: ["lg", "md", "sm", "xs"],
       default: null,
@@ -161,6 +175,13 @@ export const typography: ComponentDetails = {
       default: "",
       optional: false,
       description: "",
+    },
+    {
+      prop: "addlClassName",
+      type: ["string"],
+      default: null,
+      optional: true,
+      description: "Additional classes",
     },
     {
       prop: "size",
@@ -191,6 +212,13 @@ export const typography: ComponentDetails = {
       default: "",
       optional: false,
       description: "",
+    },
+    {
+      prop: "addlClassName",
+      type: ["string"],
+      default: null,
+      optional: true,
+      description: "Additional classes",
     },
     {
       prop: "size",

--- a/@stellar/design-system/src/components/Typography/index.tsx
+++ b/@stellar/design-system/src/components/Typography/index.tsx
@@ -11,13 +11,14 @@ interface HeadingProps extends React.HtmlHTMLAttributes<HTMLHeadingElement> {
 }
 
 export const Heading = ({
+  addlClassName,
   as: HtmlTag,
   size,
   children,
   ...props
 }: HeadingProps): JSX.Element => (
   <HtmlTag
-    className={`Heading Heading--${size} ${props.addlClassName || ""}`}
+    className={`Heading Heading--${size} ${addlClassName || ""}`}
     {...props}
   >
     {children}
@@ -36,14 +37,12 @@ interface CaptionProps extends React.HtmlHTMLAttributes<HTMLDivElement> {
 }
 
 export const Caption = ({
+  addlClassName,
   size,
   children,
   ...props
 }: CaptionProps): JSX.Element => (
-  <div
-    className={`Caption Caption--${size} ${props.addlClassName || ""}`}
-    {...props}
-  >
+  <div className={`Caption Caption--${size} ${addlClassName || ""}`} {...props}>
     {children}
   </div>
 );
@@ -62,6 +61,7 @@ interface ParagraphProps
 }
 
 export const Paragraph = ({
+  addlClassName,
   size,
   children,
   asDiv,
@@ -71,7 +71,7 @@ export const Paragraph = ({
 
   return (
     <HtmlTag
-      className={`Paragraph Paragraph--${size} ${props.addlClassName || ""}`}
+      className={`Paragraph Paragraph--${size} ${addlClassName || ""}`}
       {...props}
     >
       {children}
@@ -91,14 +91,12 @@ interface TitleProps extends React.HtmlHTMLAttributes<HTMLDivElement> {
 }
 
 export const Title = ({
+  addlClassName,
   size,
   children,
   ...props
 }: TitleProps): JSX.Element => (
-  <div
-    className={`Title Title--${size} ${props.addlClassName || ""}`}
-    {...props}
-  >
+  <div className={`Title Title--${size} ${addlClassName || ""}`} {...props}>
     {children}
   </div>
 );


### PR DESCRIPTION
I forgot to pick out `addlClassName` when adding it so React warns that it is not a known native property, this picks it out of props before spreading props onto to the dom nodes.