### PR TITLE
IconButton and ButtonPreset docs + preview

### DIFF
--- a/@stellar/design-system-website/docs/components/buttons/button-preset.mdx
+++ b/@stellar/design-system-website/docs/components/buttons/button-preset.mdx
@@ -1,0 +1,19 @@
+---
+slug: /button-preset
+---
+
+# Button preset
+
+<ComponentDescription componentName="ButtonPreset" />
+
+## Example
+
+```tsx live
+<PreviewBlock componentName="ButtonPreset">
+  <ButtonPreset preset="copy" />
+</PreviewBlock>
+```
+
+## Props
+
+<ComponentProps componentName="ButtonPreset" />

--- a/@stellar/design-system-website/docs/components/buttons/icon-button.mdx
+++ b/@stellar/design-system-website/docs/components/buttons/icon-button.mdx
@@ -4,7 +4,7 @@ slug: /icon-button
 
 # Icon button
 
-<ComponentDescription componentName="Button" />
+<ComponentDescription componentName="IconButton" />
 
 ## Example
 

--- a/@stellar/design-system-website/docs/components/buttons/icon-button.mdx
+++ b/@stellar/design-system-website/docs/components/buttons/icon-button.mdx
@@ -1,0 +1,19 @@
+---
+slug: /icon-button
+---
+
+# Icon button
+
+<ComponentDescription componentName="Button" />
+
+## Example
+
+```tsx live
+<PreviewBlock componentName="IconButton">
+  <IconButton altText="Default" icon={<Icon.Info />} />
+</PreviewBlock>
+```
+
+## Props
+
+<ComponentProps componentName="IconButton" />

--- a/@stellar/design-system-website/src/componentPreview/buttonPresetPreview.tsx
+++ b/@stellar/design-system-website/src/componentPreview/buttonPresetPreview.tsx
@@ -1,0 +1,89 @@
+import { ComponentPreview } from "@site/src/components/PreviewBlock";
+
+export const buttonPresetPreview: ComponentPreview = {
+  options: [
+    {
+      type: "checkbox",
+      prop: "disabled",
+      label: "Disabled",
+    },
+    {
+      type: "select",
+      prop: "preset",
+      options: [
+        {
+          value: "copy",
+          label: "Copy",
+        },
+        {
+          value: "download",
+          label: "Download",
+        },
+      ],
+    },
+    {
+      type: "select",
+      prop: "variant",
+      options: [
+        {
+          value: "default",
+          label: "Default",
+        },
+        {
+          value: "highlight",
+          label: "Highlight",
+        },
+      ],
+    },
+    {
+      type: "select",
+      prop: "label",
+      options: [
+        {
+          value: "",
+          label: "Default label",
+        },
+        {
+          value: "Label",
+          label: "Custom label",
+        },
+      ],
+    },
+    {
+      type: "select",
+      prop: "customSize",
+      options: [
+        {
+          value: "",
+          label: "Default size",
+        },
+        {
+          value: "2rem",
+          label: "2 rem",
+        },
+        {
+          value: "3rem",
+          label: "3 rem",
+        },
+      ],
+    },
+    {
+      type: "select",
+      prop: "customColor",
+      options: [
+        {
+          value: "",
+          label: "Default color",
+        },
+        {
+          value: "var(--color-green-50)",
+          label: "Green",
+        },
+        {
+          value: "var(--color-yellow-50)",
+          label: "Yellow",
+        },
+      ],
+    },
+  ],
+};

--- a/@stellar/design-system-website/src/componentPreview/iconButtonPreview.tsx
+++ b/@stellar/design-system-website/src/componentPreview/iconButtonPreview.tsx
@@ -1,0 +1,87 @@
+import { ComponentPreview } from "@site/src/components/PreviewBlock";
+
+export const iconButtonPreview: ComponentPreview = {
+  options: [
+    {
+      type: "checkbox",
+      prop: "disabled",
+      label: "Disabled",
+    },
+    {
+      type: "select",
+      prop: "variant",
+      options: [
+        {
+          value: "default",
+          label: "Default",
+        },
+        {
+          value: "error",
+          label: "Error",
+        },
+        {
+          value: "success",
+          label: "Success",
+        },
+        {
+          value: "warning",
+          label: "Warning",
+        },
+        {
+          value: "highlight",
+          label: "Highlight",
+        },
+      ],
+    },
+    {
+      type: "select",
+      prop: "label",
+      options: [
+        {
+          value: "",
+          label: "No label",
+        },
+        {
+          value: "Label",
+          label: "Label",
+        },
+      ],
+    },
+    {
+      type: "select",
+      prop: "customSize",
+      options: [
+        {
+          value: "",
+          label: "Default size",
+        },
+        {
+          value: "2rem",
+          label: "2 rem",
+        },
+        {
+          value: "3rem",
+          label: "3 rem",
+        },
+      ],
+    },
+    {
+      type: "select",
+      prop: "customColor",
+      options: [
+        {
+          value: "",
+          label: "Default color",
+        },
+        {
+          value: "var(--color-purple-50)",
+          label: "Purple",
+        },
+        {
+          value: "var(--color-yellow-50)",
+          label: "Yellow",
+        },
+      ],
+    },
+  ],
+};

--- a/@stellar/design-system-website/src/components/PreviewBlock/index.tsx
+++ b/@stellar/design-system-website/src/components/PreviewBlock/index.tsx
@@ -13,6 +13,7 @@ import { bannerPreview } from "@site/src/componentPreview/bannerPreview";
 import { buttonPreview } from "@site/src/componentPreview/buttonPreview";
 import { captionPreview } from "@site/src/componentPreview/captionPreview";
 import { headingPreview } from "@site/src/componentPreview/headingPreview";
+import { iconButtonPreview } from "@site/src/componentPreview/iconButtonPreview";
 import { inputPreview } from "@site/src/componentPreview/inputPreview";
 import { linkPreview } from "@site/src/componentPreview/linkPreview";
 import { loaderPreview } from "@site/src/componentPreview/loaderPreview";
@@ -36,6 +37,7 @@ const previews: { [key: string]: ComponentPreview } = {
   Button: buttonPreview,
   Caption: captionPreview,
   Heading: headingPreview,
+  IconButton: iconButtonPreview,
   Input: inputPreview,
   Link: linkPreview,
   Loader: loaderPreview,

--- a/@stellar/design-system-website/src/components/PreviewBlock/index.tsx
+++ b/@stellar/design-system-website/src/components/PreviewBlock/index.tsx
@@ -11,6 +11,7 @@ import { avatarPreview } from "@site/src/componentPreview/avatarPreview";
 import { badgePreview } from "@site/src/componentPreview/badgePreview";
 import { bannerPreview } from "@site/src/componentPreview/bannerPreview";
 import { buttonPreview } from "@site/src/componentPreview/buttonPreview";
+import { buttonPresetPreview } from "@site/src/componentPreview/buttonPresetPreview";
 import { captionPreview } from "@site/src/componentPreview/captionPreview";
 import { headingPreview } from "@site/src/componentPreview/headingPreview";
 import { iconButtonPreview } from "@site/src/componentPreview/iconButtonPreview";
@@ -35,6 +36,7 @@ const previews: { [key: string]: ComponentPreview } = {
   Badge: badgePreview,
   Banner: bannerPreview,
   Button: buttonPreview,
+  ButtonPreset: buttonPresetPreview,
   Caption: captionPreview,
   Heading: headingPreview,
   IconButton: iconButtonPreview,

--- a/@stellar/design-system/src/components/ButtonPreset/index.tsx
+++ b/@stellar/design-system/src/components/ButtonPreset/index.tsx
@@ -1,0 +1,71 @@
+import React from "react";
+import { Icon } from "../../icons";
+
+/** Including all valid [button attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#attributes) */
+export interface ButtonPresetProps {
+  /** Button preset */
+  preset: "copy" | "download";
+  /** Button variant */
+  variant?: "default" | "highlight";
+  /** Button label */
+  label?: string;
+  /** Alternative text to show on hover */
+  altText?: string;
+  /** Set custom color */
+  customColor?: string;
+  /** Set custom size */
+  customSize?: string;
+}
+
+interface Props
+  extends ButtonPresetProps,
+    React.ButtonHTMLAttributes<HTMLButtonElement> {}
+
+const presetDetails = {
+  copy: {
+    label: "Copy",
+    altText: "Copy",
+    icon: <Icon.ContentCopy />,
+  },
+  download: {
+    label: "Download",
+    altText: "Download",
+    icon: <Icon.Download />,
+  },
+};
+
+/**
+ * `ButtonPreset` is similar to the {@button Button} component, and is used to trigger an action. There are two presets `copy` and `download`, and two variants for color: `default` and `highlight`.
+ */
+export const ButtonPreset: React.FC<Props> = ({
+  altText,
+  label,
+  variant = "default",
+  preset,
+  customColor,
+  customSize,
+  ...props
+}: Props) => {
+  const customStyle = {
+    ...(customColor ? { "--IconButton-color": customColor } : {}),
+    ...(customSize ? { "--IconButton-size": customSize } : {}),
+  } as React.CSSProperties;
+
+  return (
+    <button
+      className={`IconButton IconButton--${variant}`}
+      title={altText ?? presetDetails[preset].altText}
+      {...props}
+      style={customStyle}
+    >
+      <>
+        <span className="IconButton__label">
+          {label ?? presetDetails[preset].label}
+        </span>
+        {presetDetails[preset].icon}
+      </>
+    </button>
+  );
+};
+
+ButtonPreset.displayName = "ButtonPreset";

--- a/@stellar/design-system/src/components/IconButton/index.tsx
+++ b/@stellar/design-system/src/components/IconButton/index.tsx
@@ -1,107 +1,56 @@
 import React from "react";
-import { Icon } from "../../icons";
 import "./styles.scss";
 
-enum IconButtonVariant {
-  default = "default",
-  error = "error",
-  success = "success",
-  warning = "warning",
-  highlight = "highlight",
-}
-
-enum IconButtonPreset {
-  copy = "copy",
-  download = "download",
-}
-
-interface IconButtonComponent {
-  variant: typeof IconButtonVariant;
-  preset: typeof IconButtonPreset;
-}
-
-interface IconButtonBaseProps
-  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-  variant?: IconButtonVariant;
+/** Including all valid [button attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#attributes) */
+export interface IconButtonProps {
+  /** Icon element */
+  icon: React.ReactNode;
+  /** Alternative text to show on hover */
+  altText: string;
+  /** Variant of the button */
+  variant?: "default" | "error" | "success" | "warning" | "highlight";
+  /** Button label */
   label?: string;
+  /** Set custom color */
   customColor?: string;
+  /** Set custom size */
   customSize?: string;
 }
 
-interface IconButtonDefaultProps extends IconButtonBaseProps {
-  icon: React.ReactNode;
-  altText: string;
-  preset?: IconButtonPreset;
-}
+interface Props
+  extends IconButtonProps,
+    React.ButtonHTMLAttributes<HTMLButtonElement> {}
 
-interface IconButtonPresetProps extends IconButtonBaseProps {
-  preset: IconButtonPreset;
-  icon?: React.ReactNode;
-  altText?: string;
-}
-
-type IconButtonProps = IconButtonDefaultProps | IconButtonPresetProps;
-
-const presetDetails = {
-  [IconButtonPreset.copy]: {
-    label: "Copy",
-    altText: "Copy",
-    icon: <Icon.ContentCopy />,
-  },
-  [IconButtonPreset.download]: {
-    label: "Download",
-    altText: "Download",
-    icon: <Icon.Download />,
-  },
-};
-
-export const IconButton: React.FC<IconButtonProps> & IconButtonComponent = ({
+/**
+ * `IconButton` is similar to the {@link Button} component, and is used to trigger an action. There are five variants (color is the only difference): `default`, `error`, `success`, `warning`, and `highlight`.
+ */
+export const IconButton: React.FC<Props> = ({
   icon,
   altText,
   label,
-  variant = IconButtonVariant.default,
-  preset,
+  variant = "default",
   customColor,
   customSize,
   ...props
-}: IconButtonProps) => {
+}: Props) => {
   const customStyle = {
     ...(customColor ? { "--IconButton-color": customColor } : {}),
     ...(customSize ? { "--IconButton-size": customSize } : {}),
   } as React.CSSProperties;
 
-  const renderContent = () => {
-    if (preset) {
-      return (
-        <>
-          <span className="IconButton__label">
-            {label ?? presetDetails[preset].label}
-          </span>
-          {presetDetails[preset].icon}
-        </>
-      );
-    }
-
-    return (
+  return (
+    <button
+      className={`IconButton IconButton--${variant}`}
+      title={altText}
+      {...props}
+      style={customStyle}
+    >
       <>
         {label ? <span className="IconButton__label">{label}</span> : null}
         {icon}
       </>
-    );
-  };
-
-  return (
-    <button
-      className={`IconButton IconButton--${variant}`}
-      title={preset ? presetDetails[preset].altText : altText}
-      {...props}
-      style={customStyle}
-    >
-      {renderContent()}
     </button>
   );
 };
 
 IconButton.displayName = "IconButton";
-IconButton.variant = IconButtonVariant;
-IconButton.preset = IconButtonPreset;

--- a/@stellar/design-system/src/components/IconButton/index.tsx
+++ b/@stellar/design-system/src/components/IconButton/index.tsx
@@ -22,7 +22,7 @@ interface Props
     React.ButtonHTMLAttributes<HTMLButtonElement> {}
 
 /**
- * `IconButton` is similar to the {@link Button} component, and is used to trigger an action. There are five variants (color is the only difference): `default`, `error`, `success`, `warning`, and `highlight`.
+ * `IconButton` is similar to the {@button Button} component, and is used to trigger an action. There are five variants (color is the only difference): `default`, `error`, `success`, `warning`, and `highlight`.
  */
 export const IconButton: React.FC<Props> = ({
   icon,

--- a/@stellar/design-system/src/components/index.ts
+++ b/@stellar/design-system/src/components/index.ts
@@ -3,6 +3,7 @@ export * from "./Avatar";
 export * from "./Badge";
 export * from "./Banner";
 export * from "./Button";
+export * from "./ButtonPreset";
 export * from "./Card";
 export * from "./Checkbox";
 export * from "./CopyText";


### PR DESCRIPTION
Moved the button preset to its own component for clarity because it was confusing to have them in `IconButton`.

![image](https://github.com/stellar/stellar-design-system/assets/7346473/8261e41c-cc22-4a08-8287-a038a3e5c270)

![image](https://github.com/stellar/stellar-design-system/assets/7346473/b38c18a4-f135-4b56-8971-22daae2840f8)
