### PR TITLE
Input: don't trigger password show/hide when Enter is pressed

### DIFF
--- a/@stellar/design-system-website/package.json
+++ b/@stellar/design-system-website/package.json
@@ -23,7 +23,7 @@
     "@docusaurus/remark-plugin-npm2yarn": "^2.4.3",
     "@docusaurus/theme-live-codeblock": "^2.4.1",
     "@mdx-js/react": "^1.6.22",
-    "@stellar/design-system": "^1.1.0",
+    "@stellar/design-system": "^1.1.1",
     "clsx": "^1.2.1",
     "prism-react-renderer": "^1.3.5",
     "react": "^17.0.2",

--- a/@stellar/design-system/package.json
+++ b/@stellar/design-system/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/design-system",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "author": "Stellar Development Foundation <hello@stellar.org>",
   "description": "Components for Stellar Development Foundation’s design system",
   "license": "Apache-2.0",

--- a/@stellar/design-system/src/components/Input/index.tsx
+++ b/@stellar/design-system/src/components/Input/index.tsx
@@ -128,6 +128,7 @@ export const Input: React.FC<Props> = ({
           <div className="Input__side-element">
             <button
               className="PasswordMaskToggle"
+              type="button"
               onClick={(event) => {
                 event?.preventDefault();
                 setIsPasswordMasked(!isPasswordMasked);


### PR DESCRIPTION
By default, the `button` type is `submit`, which triggered show/hide action when Enter was pressed in the form (https://github.com/stellar/stellar-disbursement-platform-backend/issues/120).