### PR TITLE
Support custom anchor elements

### DIFF
--- a/@stellar/design-system/src/components/Link/index.tsx
+++ b/@stellar/design-system/src/components/Link/index.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { cloneElement } from "react";
 import "./styles.scss";
 
 /**
@@ -21,9 +21,13 @@ export interface LinkProps {
   isUnderline?: boolean;
   /** Make the link uppercase */
   isUppercase?: boolean;
+  /** Provide a custom anchor element, for example, `Link` from Next.js */
+  customAnchor?: React.ReactElement;
+  /** Additional classes */
+  addlClassName?: string;
 }
 
-interface Props
+export interface Props
   extends LinkProps,
     React.AnchorHTMLAttributes<HTMLAnchorElement> {}
 
@@ -41,6 +45,8 @@ export const Link: React.FC<Props> = ({
   isDisabled,
   isUnderline,
   isUppercase,
+  customAnchor,
+  addlClassName,
   ...props
 }) => {
   const { href, onClick } = props;
@@ -74,6 +80,7 @@ export const Link: React.FC<Props> = ({
     ...(isDisabled ? ["Link--disabled"] : []),
     ...(isUnderline ? ["Link--underline"] : []),
     ...(isUppercase ? ["Link--uppercase"] : []),
+    ...(addlClassName ? addlClassName.split(" ") : []),
   ].join(" ");
 
   const renderIcon = (position: "left" | "right") => {
@@ -84,12 +91,27 @@ export const Link: React.FC<Props> = ({
     return null;
   };
 
-  return (
-    <a className={`Link ${additionalClasses}`} {...props} {...customProps}>
+  const renderAnchorContent = () => (
+    <>
       {renderIcon("left")}
       {children}
       {renderIcon("right")}
-    </a>
+    </>
+  );
+
+  const anchorProps = {
+    className: `Link ${additionalClasses}`,
+    ...props,
+    ...customProps,
+  };
+
+  return customAnchor ? (
+    cloneElement(customAnchor, {
+      ...anchorProps,
+      children: renderAnchorContent(),
+    })
+  ) : (
+    <a {...anchorProps}>{renderAnchorContent()}</a>
   );
 };
 

--- a/@stellar/design-system/src/components/Link/index.tsx
+++ b/@stellar/design-system/src/components/Link/index.tsx
@@ -103,15 +103,14 @@ export const Link: React.FC<Props> = ({
     className: `Link ${additionalClasses}`,
     ...props,
     ...customProps,
+    children: renderAnchorContent(),
   };
 
   return customAnchor ? (
-    cloneElement(customAnchor, {
-      ...anchorProps,
-      children: renderAnchorContent(),
-    })
+    cloneElement(customAnchor, anchorProps)
   ) : (
-    <a {...anchorProps}>{renderAnchorContent()}</a>
+    // eslint-disable-next-line jsx-a11y/anchor-has-content
+    <a {...anchorProps} />
   );
 };
 

--- a/@stellar/design-system/src/components/Profile/index.tsx
+++ b/@stellar/design-system/src/components/Profile/index.tsx
@@ -1,3 +1,4 @@
+import { cloneElement } from "react";
 import { Avatar } from "../Avatar";
 import { CopyText } from "../CopyText";
 import { Icon } from "../../icons";
@@ -21,6 +22,8 @@ export interface ProfileProps {
   hideAvatar?: boolean;
   /** Add copy address functionality */
   isCopy?: boolean;
+  /** Provide a custom anchor element, for example, `Link` from Next.js */
+  customAnchor?: React.ReactElement;
 }
 
 /**
@@ -35,6 +38,7 @@ export const Profile: React.FC<ProfileProps> = ({
   href,
   hideAvatar,
   isCopy,
+  customAnchor,
 }: ProfileProps) => {
   const address = federatedAddress ?? publicAddress;
   const additionalClasses = [
@@ -58,6 +62,9 @@ export const Profile: React.FC<ProfileProps> = ({
     if (onClick) {
       return <button {...componentProps} onClick={onClick} />;
     } else if (href) {
+      if (customAnchor) {
+        return cloneElement(customAnchor, { ...componentProps, href });
+      }
       // eslint-disable-next-line jsx-a11y/anchor-has-content
       return <a {...componentProps} href={href} />;
     }

--- a/@stellar/design-system/src/components/ProjectLogo/index.tsx
+++ b/@stellar/design-system/src/components/ProjectLogo/index.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { cloneElement } from "react";
 import { Badge } from "../Badge";
 import { Logo } from "../../logos";
 import "./styles.scss";
@@ -9,6 +9,8 @@ export interface ProjectLogoProps {
   title?: string;
   /** Project’s website link @defaultValue `/` */
   link?: string;
+  /** Provide a custom anchor element, for example, `Link` from Next.js */
+  customAnchor?: React.ReactElement;
 }
 
 /**
@@ -17,17 +19,33 @@ export interface ProjectLogoProps {
 export const ProjectLogo: React.FC<ProjectLogoProps> = ({
   title,
   link = "/",
-}) => (
-  <div className="ProjectLogo">
-    <a href={link} rel="noreferrer noopener">
-      <Logo.Stellar />
-    </a>
-    {title ? (
-      <Badge variant="secondary" size="md">
-        {title}
-      </Badge>
-    ) : null}
-  </div>
-);
+  customAnchor,
+}) => {
+  const AnchorComponent = () => {
+    const anchorProps = {
+      href: link,
+      rel: "noreferrer noopener",
+      children: <Logo.Stellar />,
+    };
+
+    if (customAnchor) {
+      return cloneElement(customAnchor, anchorProps);
+    }
+
+    // eslint-disable-next-line jsx-a11y/anchor-has-content
+    return <a {...anchorProps} />;
+  };
+
+  return (
+    <div className="ProjectLogo">
+      <AnchorComponent />
+      {title ? (
+        <Badge variant="secondary" size="md">
+          {title}
+        </Badge>
+      ) : null}
+    </div>
+  );
+};
 
 ProjectLogo.displayName = "ProjectLogo";


### PR DESCRIPTION
Updated `Link`, `Profile`, and `ProjectLogo` components to accept custom anchor elements. For example, `Link` in Next.js for client-side routing; otherwise, it would trigger a full page reload.