### PR TITLE
Label info text + updated Tooltip colors

### DIFF
--- a/@stellar/design-system-website/src/componentPreview/inputPreview.tsx
+++ b/@stellar/design-system-website/src/componentPreview/inputPreview.tsx
@@ -176,5 +176,19 @@ export const inputPreview: ComponentPreview = {
         },
       ],
     },
+    {
+      type: "select",
+      prop: "infoText",
+      options: [
+        {
+          value: "",
+          label: "No info text",
+        },
+        {
+          value: "Info text message",
+          label: "Info text",
+        },
+      ],
+    },
   ],
 };

--- a/@stellar/design-system-website/src/componentPreview/selectPreview.tsx
+++ b/@stellar/design-system-website/src/componentPreview/selectPreview.tsx
@@ -110,5 +110,19 @@ export const selectPreview: ComponentPreview = {
         },
       ],
     },
+    {
+      type: "select",
+      prop: "infoText",
+      options: [
+        {
+          value: "",
+          label: "No info text",
+        },
+        {
+          value: "Info text message",
+          label: "Info text",
+        },
+      ],
+    },
   ],
 };

--- a/@stellar/design-system-website/src/componentPreview/textareaPreview.tsx
+++ b/@stellar/design-system-website/src/componentPreview/textareaPreview.tsx
@@ -140,5 +140,19 @@ export const textareaPreview: ComponentPreview = {
         },
       ],
     },
+    {
+      type: "select",
+      prop: "infoText",
+      options: [
+        {
+          value: "",
+          label: "No info text",
+        },
+        {
+          value: "Info text message",
+          label: "Info text",
+        },
+      ],
+    },
   ],
 };

--- a/@stellar/design-system/src/components/Input/index.tsx
+++ b/@stellar/design-system/src/components/Input/index.tsx
@@ -36,6 +36,10 @@ export interface InputProps {
   customInput?: React.ReactElement;
   /** Copy button options */
   copyButton?: InputCopyButton;
+  /** Info text tooltip */
+  infoText?: string | React.ReactNode;
+  /** Custom info text icon @defaultValue `<Icon.InfoCircle />` */
+  infoTextIcon?: React.ReactNode;
 }
 
 /** */
@@ -70,6 +74,8 @@ export const Input: React.FC<Props> = ({
   error,
   success,
   copyButton,
+  infoText,
+  infoTextIcon,
   ...props
 }: Props) => {
   const [isPasswordMasked, setIsPasswordMasked] = useState(true);
@@ -101,6 +107,8 @@ export const Input: React.FC<Props> = ({
           isUppercase={isLabelUppercase}
           size={fieldSize}
           labelSuffix={labelSuffix}
+          infoText={infoText}
+          infoTextIcon={infoTextIcon}
         >
           {label}
         </Label>

--- a/@stellar/design-system/src/components/Label/index.tsx
+++ b/@stellar/design-system/src/components/Label/index.tsx
@@ -1,4 +1,6 @@
 import React from "react";
+import { Tooltip } from "../Tooltip";
+import { Icon } from "../../icons";
 import "./styles.scss";
 
 interface LabelProps extends React.LabelHTMLAttributes<HTMLLabelElement> {
@@ -7,6 +9,8 @@ interface LabelProps extends React.LabelHTMLAttributes<HTMLLabelElement> {
   size: "sm" | "md" | "lg";
   isUppercase?: boolean;
   labelSuffix?: string | React.ReactNode;
+  infoText?: string | React.ReactNode;
+  infoTextIcon?: React.ReactNode;
 }
 
 export const Label: React.FC<LabelProps> = ({
@@ -15,6 +19,8 @@ export const Label: React.FC<LabelProps> = ({
   size = "sm",
   isUppercase,
   labelSuffix,
+  infoText,
+  infoTextIcon = <Icon.InfoCircle />,
   ...props
 }: LabelProps) => {
   const additionalClasses = [
@@ -23,16 +29,30 @@ export const Label: React.FC<LabelProps> = ({
   ].join(" ");
 
   return (
-    <label
-      className={`Label ${additionalClasses}`}
-      htmlFor={htmlFor}
-      {...props}
-    >
-      {children}
-      {labelSuffix ? (
-        <span className="Label__suffix">({labelSuffix})</span>
+    <div className="Label__wrapper">
+      <label
+        className={`Label ${additionalClasses}`}
+        htmlFor={htmlFor}
+        {...props}
+      >
+        {children}
+        {labelSuffix ? (
+          <span className="Label__suffix">({labelSuffix})</span>
+        ) : null}
+      </label>
+
+      {infoText ? (
+        <Tooltip
+          triggerEl={
+            <div className="Label__infoButton" role="button">
+              {infoTextIcon}
+            </div>
+          }
+        >
+          {infoText}
+        </Tooltip>
       ) : null}
-    </label>
+    </div>
   );
 };
 

--- a/@stellar/design-system/src/components/Label/styles.scss
+++ b/@stellar/design-system/src/components/Label/styles.scss
@@ -1,25 +1,36 @@
 @use "../../utils.scss" as *;
 
 .Label {
+  --Label-height: #{pxToRem(18px)};
+
   font-family: var(--sds-ff-base);
   font-weight: var(--sds-fw-medium);
   color: var(--sds-clr-gray-11);
   display: flex;
   gap: pxToRem(2px);
 
+  &__wrapper {
+    display: inline-flex;
+    align-items: center;
+    gap: pxToRem(4px);
+  }
+
   &--sm {
+    --Label-height: #{pxToRem(18px)};
     font-size: pxToRem(12px);
-    line-height: pxToRem(18px);
+    line-height: var(--Label-height);
   }
 
   &--md {
+    --Label-height: #{pxToRem(18px)};
     font-size: pxToRem(12px);
-    line-height: pxToRem(18px);
+    line-height: var(--Label-height);
   }
 
   &--lg {
+    --Label-height: #{pxToRem(20px)};
     font-size: pxToRem(14px);
-    line-height: pxToRem(20px);
+    line-height: var(--Label-height);
   }
 
   &--uppercase {
@@ -28,5 +39,18 @@
 
   &__suffix {
     color: var(--sds-clr-gray-11);
+  }
+
+  &__infoButton {
+    width: var(--Label-height);
+    height: var(--Label-height);
+    cursor: pointer;
+
+    svg {
+      display: block;
+      width: 100%;
+      height: 100%;
+      stroke: var(--sds-clr-gray-08);
+    }
   }
 }

--- a/@stellar/design-system/src/components/Select/index.tsx
+++ b/@stellar/design-system/src/components/Select/index.tsx
@@ -23,6 +23,10 @@ export interface SelectProps {
   error?: string | string;
   /** Success message of the input */
   success?: string | React.ReactNode;
+  /** Info text tooltip */
+  infoText?: string | React.ReactNode;
+  /** Custom info text icon @defaultValue `<Icon.InfoCircle />` */
+  infoTextIcon?: React.ReactNode;
   /** Make label uppercase */
   isLabelUppercase?: boolean;
   /** Select error without a message */
@@ -50,6 +54,8 @@ export const Select: React.FC<Props> = ({
   note,
   error,
   success,
+  infoText,
+  infoTextIcon,
   isLabelUppercase,
   isError,
   customSelect,
@@ -74,6 +80,8 @@ export const Select: React.FC<Props> = ({
           isUppercase={isLabelUppercase}
           size={fieldSize}
           labelSuffix={labelSuffix}
+          infoText={infoText}
+          infoTextIcon={infoTextIcon}
         >
           {label}
         </Label>

--- a/@stellar/design-system/src/components/Textarea/index.tsx
+++ b/@stellar/design-system/src/components/Textarea/index.tsx
@@ -23,6 +23,10 @@ export interface TextareaProps {
   error?: string | React.ReactNode;
   /** Success message of the input */
   success?: string | React.ReactNode;
+  /** Info text tooltip */
+  infoText?: string | React.ReactNode;
+  /** Custom info text icon @defaultValue `<Icon.InfoCircle />` */
+  infoTextIcon?: React.ReactNode;
   /** Textarea error without a message */
   isError?: boolean;
   /** Make label uppercase */
@@ -52,6 +56,8 @@ export const Textarea: React.FC<Props> = ({
   note,
   error,
   success,
+  infoText,
+  infoTextIcon,
   isError,
   isLabelUppercase,
   hasCopyButton,
@@ -81,6 +87,8 @@ export const Textarea: React.FC<Props> = ({
           isUppercase={isLabelUppercase}
           size={fieldSize}
           labelSuffix={labelSuffix}
+          infoText={infoText}
+          infoTextIcon={infoTextIcon}
         >
           {label}
         </Label>

--- a/@stellar/design-system/src/components/ThemeSwitch/index.tsx
+++ b/@stellar/design-system/src/components/ThemeSwitch/index.tsx
@@ -66,6 +66,16 @@ export const ThemeSwitch = ({
     }
   }, [disableSetThemeOnLoad, isDarkMode]);
 
+  // Trigger custom event to get the current theme
+  useEffect(() => {
+    document.dispatchEvent(
+      new CustomEvent<{ theme: string }>("SDS_ThemeSwitchEvent", {
+        bubbles: true,
+        detail: { theme: isDarkMode ? ThemeMode.DARK : ThemeMode.LIGHT },
+      }),
+    );
+  }, [isDarkMode]);
+
   const handleSwitch = () => {
     const _isDarkMode = !isDarkMode;
 

--- a/@stellar/design-system/src/components/Tooltip/index.tsx
+++ b/@stellar/design-system/src/components/Tooltip/index.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import { Floater } from "../Floater";
 import "./styles.scss";
 
@@ -40,6 +41,21 @@ export const Tooltip: React.FC<TooltipProps> = ({
   isVisible,
   isContrast = true,
 }: TooltipProps) => {
+  const [theme, setTheme] = useState("sds-theme-dark");
+
+  useEffect(() => {
+    document.addEventListener("SDS_ThemeSwitchEvent", ((
+      event: CustomEvent<{ theme: string }>,
+    ) => {
+      if (event.detail?.theme) {
+        setTheme(event.detail.theme);
+      }
+    }) as EventListener);
+  }, []);
+
+  const getContrastMode = () =>
+    theme === "sds-theme-dark" ? "sds-theme-light" : "sds-theme-dark";
+
   return (
     <Floater
       placement={placement}
@@ -48,7 +64,7 @@ export const Tooltip: React.FC<TooltipProps> = ({
       isContrast={isContrast}
       showArrow={true}
     >
-      <div className="Tooltip">
+      <div className={`Tooltip ${isContrast ? getContrastMode() : ""}`}>
         {title ? <div className="Tooltip__title">{title}</div> : null}
         {children ? <div className="Tooltip__message">{children}</div> : null}
       </div>

--- a/@stellar/design-system/src/components/Tooltip/styles.scss
+++ b/@stellar/design-system/src/components/Tooltip/styles.scss
@@ -12,12 +12,13 @@
     font-size: pxToRem(12px);
     line-height: pxToRem(18px);
     font-weight: var(--sds-fw-semi-bold);
+    color: var(--sds-clr-gray-12);
   }
 
   &__message {
     font-size: pxToRem(12px);
     line-height: pxToRem(18px);
     font-weight: var(--sds-fw-medium);
-    color: var(--sds-clr-gray-08);
+    color: var(--sds-clr-gray-11);
   }
 }


### PR DESCRIPTION
- Added info text tooltip prop to `Label`, `Input`, `Select`, and `Textarea` components.
- `Tooltip` content will correctly switch colors in contrast mode (when showing a dark bubble).

<details>
<summary>Examples</summary>

![image](https://github.com/stellar/stellar-design-system/assets/7346473/ee0dc0dd-f5f9-4afd-885e-e19d1c5d67ed)

![image](https://github.com/stellar/stellar-design-system/assets/7346473/bc4b424f-d0f5-4fb2-b4ad-3e552c96ec30)
</details>

>[!NOTE]
>The SDS website doesn't show the correct Tooltip bubble theme when using light mode in the component preview because it's not using a global theme (Docusaurus controls that). It looks fine in the dark mode because that is the default. It should work as expected in projects that use SDS globally.