### PR TITLE
UI fixes: floater z-index + input and textarea fixes

### DIFF
--- a/@stellar/design-system/src/components/Floater/styles.scss
+++ b/@stellar/design-system/src/components/Floater/styles.scss
@@ -50,6 +50,8 @@
 
   // Floater open/close
   &.trigger {
+    z-index: 2;
+
     .Floater__content {
       display: block;
     }

--- a/@stellar/design-system/src/components/Input/styles.scss
+++ b/@stellar/design-system/src/components/Input/styles.scss
@@ -64,7 +64,8 @@
     color: var(--Input-color-text);
     border-radius: var(--Input-border-radius);
     box-shadow: 0 0 0 var(--Input-box-shadow-size) var(--Input-box-shadow-color);
-    transition: border-color var(--sds-anim-transition-default),
+    transition:
+      border-color var(--sds-anim-transition-default),
       box-shadow var(--sds-anim-transition-default);
 
     padding-left: var(--Input-padding-horizontal);
@@ -103,6 +104,10 @@
       &:hover {
         border-color: var(--Input-color-border-hover);
       }
+    }
+
+    & > * {
+      min-width: 0;
     }
   }
 

--- a/@stellar/design-system/src/components/Textarea/index.tsx
+++ b/@stellar/design-system/src/components/Textarea/index.tsx
@@ -79,6 +79,8 @@ export const Textarea: React.FC<Props> = ({
     autoComplete,
   };
 
+  const val = (props.value || children) as string;
+
   return (
     <div className={`Textarea ${additionalClasses}`}>
       {label && (
@@ -98,7 +100,7 @@ export const Textarea: React.FC<Props> = ({
         cloneElement(customTextarea, { ...baseTextareaProps, ...props })
       ) : (
         <textarea {...baseTextareaProps} {...props}>
-          {children}
+          {val}
         </textarea>
       )}
 
@@ -118,7 +120,7 @@ export const Textarea: React.FC<Props> = ({
             )}
           </div>
           {hasCopyButton ? (
-            <InputCopyButton fieldSize={fieldSize} textToCopy={children} />
+            <InputCopyButton fieldSize={fieldSize} textToCopy={val} />
           ) : null}
         </div>
       )}


### PR DESCRIPTION
- Fix Floater z-index when the tooltip is open (fixes Copy button overlap for Input)
- Fix Input element width to allow shrinking when the Input is small
- Fix Textarea value to allow both value and children (used to have only children)