### PR TITLE
allow Toggle to be tabbed and add focus styling

### DIFF
--- a/@stellar/design-system/src/components/Toggle/styles.scss
+++ b/@stellar/design-system/src/components/Toggle/styles.scss
@@ -68,7 +68,12 @@
   }
 
   &__input {
-    display: none;
+    height: 0;
+    width: 0;
+
+    &:focus-visible ~ .Toggle__track {
+      box-shadow: 0 0 0 pxToRem(2px) var(--sds-input-color-border-default-focus);
+    }
 
     &:checked ~ .Toggle__track {
       background-color: var(--sds-clr-lilac-09);


### PR DESCRIPTION
We discovered the Toggle component wasn't able to be tabbed to using the keyboard because the underlying input is set to `display: none`, which is an accessibility issue

This PR works around this by setting height and width to 0. It also adds focus styling

Unfocused:
<img width="184" alt="Screenshot 2024-12-04 at 1 48 22 PM" src="https://github.com/user-attachments/assets/8adc4528-4e7f-4afb-8b3d-245bbdaebbcc">

Focused:
<img width="140" alt="Screenshot 2024-12-04 at 1 48 18 PM" src="https://github.com/user-attachments/assets/b47c2da0-9478-4e52-b29d-04cb2a56fe36">

