### PR TITLE
Allow custom icons for info link and text

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ yarn-error.log*
 
 # vs code
 /.vscode
+
+# jetbrains
+/.idea

--- a/@stellar/design-system-website/package.json
+++ b/@stellar/design-system-website/package.json
@@ -26,7 +26,7 @@
     "@docusaurus/remark-plugin-npm2yarn": "^3.7.0",
     "@docusaurus/theme-live-codeblock": "^3.7.0",
     "@mdx-js/react": "^3.1.0",
-    "@stellar/design-system": "^3.1.0",
+    "@stellar/design-system": "^3.1.1",
     "clsx": "^2.1.1",
     "prism-react-renderer": "^2.4.1",
     "react": "^18.3.1",

--- a/@stellar/design-system/package.json
+++ b/@stellar/design-system/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/design-system",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "author": "Stellar Development Foundation <hello@stellar.org>",
   "description": "Components for Stellar Development Foundation’s design system",
   "license": "Apache-2.0",

--- a/@stellar/design-system/src/components/Input/index.tsx
+++ b/@stellar/design-system/src/components/Input/index.tsx
@@ -38,8 +38,12 @@ export interface InputProps {
   copyButton?: InputCopyButton;
   /** Info text tooltip */
   infoText?: string | React.ReactNode;
+  /** Info text icon @defaultValue `<Icon.InfoCircle />` */
+  infoTextIcon?: React.ReactNode;
   /** External link to open in new window */
   infoLink?: string;
+  /** Info link icon @defaultValue `<Icon.BookOpen01 />` */
+  infoLinkIcon?: React.ReactNode;
 }
 
 /** */
@@ -75,7 +79,9 @@ export const Input: React.FC<Props> = ({
   success,
   copyButton,
   infoText,
+  infoTextIcon = <Icon.InfoCircle />,
   infoLink,
+  infoLinkIcon = <Icon.BookOpen01 />,
   ...props
 }: Props) => {
   const [isPasswordMasked, setIsPasswordMasked] = useState(true);
@@ -108,7 +114,9 @@ export const Input: React.FC<Props> = ({
           size={fieldSize}
           labelSuffix={labelSuffix}
           infoText={infoText}
+          infoTextIcon={infoTextIcon}
           infoLink={infoLink}
+          infoLinkIcon={infoLinkIcon}
         >
           {label}
         </Label>

--- a/@stellar/design-system/src/components/Label/index.tsx
+++ b/@stellar/design-system/src/components/Label/index.tsx
@@ -10,7 +10,9 @@ interface LabelProps extends React.LabelHTMLAttributes<HTMLLabelElement> {
   isUppercase?: boolean;
   labelSuffix?: string | React.ReactNode;
   infoText?: string | React.ReactNode;
+  infoTextIcon?: React.ReactNode;
   infoLink?: string;
+  infoLinkIcon?: React.ReactNode;
 }
 
 export const Label: React.FC<LabelProps> = ({
@@ -20,7 +22,9 @@ export const Label: React.FC<LabelProps> = ({
   isUppercase,
   labelSuffix,
   infoText,
+  infoTextIcon = <Icon.InfoCircle />,
   infoLink,
+  infoLinkIcon = <Icon.BookOpen01 />,
   ...props
 }: LabelProps) => {
   const additionalClasses = [
@@ -48,7 +52,7 @@ export const Label: React.FC<LabelProps> = ({
           rel="noreferrer noopener"
           target="_blank"
         >
-          <Icon.BookOpen01 />
+          {infoLinkIcon}
         </a>
       ) : null}
 
@@ -56,7 +60,7 @@ export const Label: React.FC<LabelProps> = ({
         <Tooltip
           triggerEl={
             <div className="Label__infoButton" role="button">
-              <Icon.InfoCircle />
+              {infoTextIcon}
             </div>
           }
         >

--- a/@stellar/design-system/src/components/Select/index.tsx
+++ b/@stellar/design-system/src/components/Select/index.tsx
@@ -1,7 +1,7 @@
 import React, { cloneElement } from "react";
 import { Label } from "../Label";
-import { FieldNote } from "../utils/FieldNote";
 import { Icon } from "../../icons";
+import { FieldNote } from "../utils/FieldNote";
 import "./styles.scss";
 
 /** Including all valid [select attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select#attributes). */
@@ -25,8 +25,12 @@ export interface SelectProps {
   success?: string | React.ReactNode;
   /** Info text tooltip */
   infoText?: string | React.ReactNode;
+  /** Info text icon @defaultValue `<Icon.InfoCircle />` */
+  infoTextIcon?: React.ReactNode;
   /** External link to open in new window */
   infoLink?: string;
+  /** Info link icon @defaultValue `<Icon.BookOpen01 />` */
+  infoLinkIcon?: React.ReactNode;
   /** Make label uppercase */
   isLabelUppercase?: boolean;
   /** Select error without a message */
@@ -55,7 +59,9 @@ export const Select: React.FC<Props> = ({
   error,
   success,
   infoText,
+  infoTextIcon = <Icon.InfoCircle />,
   infoLink,
+  infoLinkIcon = <Icon.BookOpen01 />,
   isLabelUppercase,
   isError,
   customSelect,
@@ -81,7 +87,9 @@ export const Select: React.FC<Props> = ({
           size={fieldSize}
           labelSuffix={labelSuffix}
           infoText={infoText}
+          infoTextIcon={infoTextIcon}
           infoLink={infoLink}
+          infoLinkIcon={infoLinkIcon}
         >
           {label}
         </Label>

--- a/@stellar/design-system/src/components/Textarea/index.tsx
+++ b/@stellar/design-system/src/components/Textarea/index.tsx
@@ -1,5 +1,6 @@
 import React, { cloneElement } from "react";
 import { Label } from "../Label";
+import { Icon } from "../../icons";
 import { FieldNote } from "../utils/FieldNote";
 import { InputCopyButton } from "../utils/InputCopyButton";
 import "./styles.scss";
@@ -25,8 +26,12 @@ export interface TextareaProps {
   success?: string | React.ReactNode;
   /** Info text tooltip */
   infoText?: string | React.ReactNode;
+  /** Info text icon @defaultValue `<Icon.InfoCircle />` */
+  infoTextIcon?: React.ReactNode;
   /** External link to open in new window */
   infoLink?: string;
+  /** Info link icon @defaultValue `<Icon.BookOpen01 />` */
+  infoLinkIcon?: React.ReactNode;
   /** Textarea error without a message */
   isError?: boolean;
   /** Make label uppercase */
@@ -57,7 +62,9 @@ export const Textarea: React.FC<Props> = ({
   error,
   success,
   infoText,
+  infoTextIcon = <Icon.InfoCircle />,
   infoLink,
+  infoLinkIcon = <Icon.BookOpen01 />,
   isError,
   isLabelUppercase,
   hasCopyButton,
@@ -90,7 +97,9 @@ export const Textarea: React.FC<Props> = ({
           size={fieldSize}
           labelSuffix={labelSuffix}
           infoText={infoText}
+          infoTextIcon={infoTextIcon}
           infoLink={infoLink}
+          infoLinkIcon={infoLinkIcon}
         >
           {label}
         </Label>


### PR DESCRIPTION
- Add optional `infoTextIcon` and `infoLinkIcon` props to `Input`, `Select`, and `Textarea` components to allow setting custom icons.
- Bump SDS version to `3.1.1`