### PR TITLE
move to npm trusted publishing

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -2,6 +2,11 @@ name: Publish npm package
 on:
   release:
     types: [published]
+
+permissions:
+  id-token: write  # Required for OIDC
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -14,6 +19,4 @@ jobs:
 
       - run: yarn install
       - run: yarn build
-      - run: npm publish --workspace @stellar/design-system --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - run: npm publish --workspace @stellar/design-system --access public --provenance


### PR DESCRIPTION
Update npm publish workflow to include provenance. Trust relationship already exists on npmjs