### PR TITLE
Update docker base image to 24.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04 as build
+FROM ubuntu:24.04 as build
 
 LABEL maintainer="SDF Ops Team <ops@stellar.org>"
 


### PR DESCRIPTION
### What:

Update docker base image to 24.04

### Why:
Docker base image needs to updated to 24.04


### Issue:

https://github.com/stellar/ops/issues/4358
