### PR TITLE
Fix `<Notification/>` bug

### DIFF
--- a/@stellar/design-system-website/src/componentPreview/notificationPreview.tsx
+++ b/@stellar/design-system-website/src/componentPreview/notificationPreview.tsx
@@ -13,10 +13,6 @@ export const notificationPreview: ComponentPreview = {
           label: "Primary",
         },
         {
-          value: "secondary",
-          label: "Secondary",
-        },
-        {
           value: "success",
           label: "Success",
         },

--- a/@stellar/design-system/src/components/Banner/index.tsx
+++ b/@stellar/design-system/src/components/Banner/index.tsx
@@ -9,7 +9,7 @@ export interface BannerProps {
   /** Notification icon @defaultValue `<Icon.InfoCircle />` */
   icon?: React.ReactNode;
   /** Message to display in the banner */
-  children: string | React.ReactNode;
+  children: React.ReactNode;
 }
 
 /**

--- a/@stellar/design-system/src/components/Button/index.tsx
+++ b/@stellar/design-system/src/components/Button/index.tsx
@@ -19,7 +19,7 @@ export interface ButtonProps {
   /** Size of the button */
   size: "sm" | "md" | "lg" | "xl";
   /** Label of the button */
-  children?: string | React.ReactNode;
+  children?: React.ReactNode;
   /** Icon element */
   icon?: React.ReactNode;
   /** Position of the icon @defaultValue `right` */

--- a/@stellar/design-system/src/components/Checkbox/index.tsx
+++ b/@stellar/design-system/src/components/Checkbox/index.tsx
@@ -11,19 +11,20 @@ export interface CheckboxProps {
   /** Size of the checkbox */
   fieldSize: "sm" | "md" | "lg";
   /** Label of the checkbox */
-  label?: string | React.ReactNode;
+  label?: React.ReactNode;
   /** Note message of the checkbox */
-  note?: string | React.ReactNode;
+  note?: React.ReactNode;
   /** Error message of the checkbox */
-  error?: string | React.ReactNode;
+  error?: React.ReactNode;
   /** Success message of the input */
-  success?: string | React.ReactNode;
+  success?: React.ReactNode;
   /** Checkbox error without a message */
   isError?: boolean;
 }
 
 interface Props
-  extends CheckboxProps, React.InputHTMLAttributes<HTMLInputElement> {
+  extends CheckboxProps,
+    React.InputHTMLAttributes<HTMLInputElement> {
   id: string;
 }
 

--- a/@stellar/design-system/src/components/Input/index.tsx
+++ b/@stellar/design-system/src/components/Input/index.tsx
@@ -13,9 +13,9 @@ export interface InputProps {
   /** Size of the input */
   fieldSize: "sm" | "md" | "lg";
   /** Label of the input */
-  label?: string | React.ReactNode;
+  label?: React.ReactNode;
   /** Adds suffix to the label */
-  labelSuffix?: string | React.ReactNode;
+  labelSuffix?: React.ReactNode;
   /** Make label uppercase */
   isLabelUppercase?: boolean;
   /** Input error without a message */
@@ -23,21 +23,21 @@ export interface InputProps {
   /** Password input preset with show/hide button */
   isPassword?: boolean;
   /** Left side element of the input. */
-  leftElement?: string | React.ReactNode;
+  leftElement?: React.ReactNode;
   /** Right side element of the input. */
-  rightElement?: string | React.ReactNode;
+  rightElement?: React.ReactNode;
   /** Note message of the input */
-  note?: string | React.ReactNode;
+  note?: React.ReactNode;
   /** Error message of the input */
-  error?: string | React.ReactNode;
+  error?: React.ReactNode;
   /** Success message of the input */
-  success?: string | React.ReactNode;
+  success?: React.ReactNode;
   /** Use a specific input rather than a generic HTML input (useful for Formik or otherwise controlled inputs) */
   customInput?: React.ReactElement;
   /** Copy button options */
   copyButton?: InputCopyButton;
   /** Info text tooltip */
-  infoText?: string | React.ReactNode;
+  infoText?: React.ReactNode;
   /** Info text icon @defaultValue `<Icon.InfoCircle />` */
   infoTextIcon?: React.ReactNode;
   /** External link to open in new window */

--- a/@stellar/design-system/src/components/Label/index.tsx
+++ b/@stellar/design-system/src/components/Label/index.tsx
@@ -5,12 +5,12 @@ import { Icon } from "../../icons";
 import "./styles.scss";
 
 interface LabelProps extends React.LabelHTMLAttributes<HTMLLabelElement> {
-  children: string | React.ReactNode;
+  children: React.ReactNode;
   htmlFor: string;
   size: "sm" | "md" | "lg";
   isUppercase?: boolean;
-  labelSuffix?: string | React.ReactNode;
-  infoText?: string | React.ReactNode;
+  labelSuffix?: React.ReactNode;
+  infoText?: React.ReactNode;
   infoTextIcon?: React.ReactNode;
   infoLink?: string;
   infoLinkIcon?: React.ReactNode;

--- a/@stellar/design-system/src/components/Link/index.tsx
+++ b/@stellar/design-system/src/components/Link/index.tsx
@@ -6,7 +6,7 @@ import "./styles.scss";
  */
 export interface LinkProps {
   /** Content of the link */
-  children?: string | React.ReactNode;
+  children?: React.ReactNode;
   /** Variant of the link @defaultValue `primary` */
   variant?: "primary" | "secondary" | "success" | "warning" | "error";
   /** Size of the link, will inherit parent size if not set */

--- a/@stellar/design-system/src/components/Modal/index.tsx
+++ b/@stellar/design-system/src/components/Modal/index.tsx
@@ -17,7 +17,7 @@ interface ModalComponent {
 /** */
 export interface ModalHeadingProps {
   /** Content of the modal heading */
-  children: string | React.ReactNode;
+  children: React.ReactNode;
 }
 
 const ModalHeading = ({ children }: ModalHeadingProps): React.ReactElement => (

--- a/@stellar/design-system/src/components/Notification/index.tsx
+++ b/@stellar/design-system/src/components/Notification/index.tsx
@@ -7,9 +7,9 @@ import "./styles.scss";
 /** */
 export interface NotificationBaseProps {
   /** Variant of the notification */
-  variant: "primary" | "secondary" | "success" | "error" | "warning";
+  variant: "primary" | "success" | "error" | "warning";
   /** Notification title */
-  title: string;
+  title: string | React.ReactNode;
   /** Notification icon @defaultValue `<Icon.InfoCircle />` */
   icon?: React.ReactNode;
   /** Notification background */
@@ -25,7 +25,7 @@ export type NotificationActionButton = {
   /** Notification action label @defaultValue `Action` */
   actionLabel?: string;
   /** Notification action link */
-  actionLink?: undefined;
+  actionLink?: string;
   /** Dismiss and close action */
   onClose?: () => void;
 };
@@ -38,7 +38,7 @@ export interface NotificationProps
 // TODO: Notification: floating with max width
 
 /**
- * Use `notification` to draw a user's attention. There are five variants `primary`, `secondary`, `success`, `error`, and `warning`.
+ * Use `notification` to draw a user's attention. There are five variants `primary`,  `success`, `error`, and `warning`.
  */
 export const Notification = ({
   variant,

--- a/@stellar/design-system/src/components/Notification/index.tsx
+++ b/@stellar/design-system/src/components/Notification/index.tsx
@@ -9,13 +9,13 @@ export interface NotificationBaseProps {
   /** Variant of the notification */
   variant: "primary" | "success" | "error" | "warning";
   /** Notification title */
-  title: string | React.ReactNode;
+  title: React.ReactNode;
   /** Notification icon @defaultValue `<Icon.InfoCircle />` */
   icon?: React.ReactNode;
   /** Notification background */
   isFilled?: boolean;
   /** Notification message */
-  children?: string | React.ReactNode;
+  children?: React.ReactNode;
 }
 
 /** */

--- a/@stellar/design-system/src/components/Notification/index.tsx
+++ b/@stellar/design-system/src/components/Notification/index.tsx
@@ -24,8 +24,6 @@ export type NotificationActionButton = {
   onAction?: () => void;
   /** Notification action label @defaultValue `Action` */
   actionLabel?: string;
-  /** Notification action link */
-  actionLink?: string;
   /** Dismiss and close action */
   onClose?: () => void;
 };
@@ -48,7 +46,6 @@ export const Notification = ({
   children,
   onAction,
   onClose,
-  actionLink,
   actionLabel = "Action",
 }: NotificationProps): React.ReactElement => {
   const additionalClasses = [
@@ -57,12 +54,12 @@ export const Notification = ({
   ].join(" ");
 
   const renderActionElement = () => {
-    if (!(onAction || actionLink)) {
+    if (!onAction) {
       return null;
     }
 
     return (
-      <Button variant={getActionVariant()} size="md">
+      <Button variant={getActionVariant()} onClick={onAction} size="md">
         {actionLabel}
       </Button>
     );
@@ -103,7 +100,7 @@ export const Notification = ({
             ) : null}
           </div>
 
-          {onClose || onAction || actionLink ? (
+          {onClose || onAction ? (
             <div className="Notification__content__buttons">
               {renderDismissElement()}
 

--- a/@stellar/design-system/src/components/Notification/index.tsx
+++ b/@stellar/design-system/src/components/Notification/index.tsx
@@ -71,14 +71,14 @@ export const Notification = ({
     }
 
     return (
-      <Button variant="tertiary" onClick={onClose} size="md">
+      <Button variant="error" onClick={onClose} size="md">
         Dismiss
       </Button>
     );
   };
 
   const getActionVariant = () => {
-    return variant === "error" ? "error" : "primary";
+    return variant === "error" ? "error" : "tertiary";
   };
 
   return (
@@ -102,9 +102,8 @@ export const Notification = ({
 
           {onClose || onAction ? (
             <div className="Notification__content__buttons">
-              {renderDismissElement()}
-
               {renderActionElement()}
+              {renderDismissElement()}
             </div>
           ) : null}
         </div>

--- a/@stellar/design-system/src/components/Notification/index.tsx
+++ b/@stellar/design-system/src/components/Notification/index.tsx
@@ -38,7 +38,7 @@ export interface NotificationProps
 // TODO: Notification: floating with max width
 
 /**
- * Use `notification` to draw a user's attention. There are five variants `primary`,  `success`, `error`, and `warning`.
+ * Use `notification` to draw a user's attention. There are five variants `primary`, `success`, `error`, and `warning`.
  */
 export const Notification = ({
   variant,
@@ -97,7 +97,9 @@ export const Notification = ({
             <div className="Notification__content__title">{title}</div>
 
             {children ? (
-              <div className="Notification__content__message">{children}</div>
+              <div className="Notification__content__message">
+                <div>{children}</div>
+              </div>
             ) : null}
           </div>
 

--- a/@stellar/design-system/src/components/Notification/styles.scss
+++ b/@stellar/design-system/src/components/Notification/styles.scss
@@ -99,6 +99,10 @@
     --Notification-color-border: var(--sds-clr-lilac-06);
     --Notification-color-icon: var(--sds-clr-lilac-09);
     --Notification-color-action: var(--sds-clr-lilac-11);
+
+    &.Notification--filled {
+      --Notification-color-background: var(--sds-clr-lilac-03);
+    }
   }
 
   &--success {

--- a/@stellar/design-system/src/components/Notification/styles.scss
+++ b/@stellar/design-system/src/components/Notification/styles.scss
@@ -2,8 +2,8 @@
 
 .Notification {
   // Variables
-  --Notification-color-background: var(--sds-clr-gray-01);
-  --Notification-color-border: var(--sds-clr-gray-06);
+  --Notification-color-background: var(--sds-clr-lilac-01);
+  --Notification-color-border: var(--sds-clr-lilac-06);
   --Notification-color-icon: var(--sds-clr-lilac-09);
   --Notification-color-action: var(--sds-clr-lilac-11);
 
@@ -95,15 +95,8 @@
 
   // Variant
   &--primary {
-    --Notification-color-background: var(--sds-clr-gray-01);
-    --Notification-color-border: var(--sds-clr-gray-06);
-    --Notification-color-icon: var(--sds-clr-lilac-09);
-    --Notification-color-action: var(--sds-clr-lilac-11);
-  }
-
-  &--secondary {
-    --Notification-color-background: var(--sds-clr-gray-03);
-    --Notification-color-border: var(--sds-clr-gray-06);
+    --Notification-color-background: var(--sds-clr-lilac-01);
+    --Notification-color-border: var(--sds-clr-lilac-06);
     --Notification-color-icon: var(--sds-clr-lilac-09);
     --Notification-color-action: var(--sds-clr-lilac-11);
   }

--- a/@stellar/design-system/src/components/RadioButton/index.tsx
+++ b/@stellar/design-system/src/components/RadioButton/index.tsx
@@ -6,14 +6,15 @@ export interface RadioButtonProps {
   /** ID of the radio button (should be unique) */
   id: string;
   /** Label of the radio button */
-  label: string | React.ReactNode;
+  label: React.ReactNode;
   // Note: cannot use "size" here because it's input's native property
   /** Size of the radio button */
   fieldSize: "sm" | "md" | "lg";
 }
 
 interface Props
-  extends RadioButtonProps, React.InputHTMLAttributes<HTMLInputElement> {
+  extends RadioButtonProps,
+    React.InputHTMLAttributes<HTMLInputElement> {
   id: string;
 }
 

--- a/@stellar/design-system/src/components/Select/index.tsx
+++ b/@stellar/design-system/src/components/Select/index.tsx
@@ -14,17 +14,17 @@ export interface SelectProps {
   /** Select options or optgroup with options */
   children: React.ReactNode;
   /** Label of the select */
-  label?: string | React.ReactNode;
+  label?: React.ReactNode;
   /** Adds suffix to the label */
-  labelSuffix?: string | React.ReactNode;
+  labelSuffix?: React.ReactNode;
   /** Note message of the select */
-  note?: string | React.ReactNode;
+  note?: React.ReactNode;
   /** Error message of the select */
   error?: string | string;
   /** Success message of the input */
-  success?: string | React.ReactNode;
+  success?: React.ReactNode;
   /** Info text tooltip */
-  infoText?: string | React.ReactNode;
+  infoText?: React.ReactNode;
   /** Info text icon @defaultValue `<Icon.InfoCircle />` */
   infoTextIcon?: React.ReactNode;
   /** External link to open in new window */

--- a/@stellar/design-system/src/components/Table/index.tsx
+++ b/@stellar/design-system/src/components/Table/index.tsx
@@ -12,7 +12,7 @@ export interface TableColumnLabel {
   /** Path to data property in object, it is used in sorting */
   id: string;
   /** Column label */
-  label: string | React.ReactNode;
+  label: React.ReactNode;
   /** Enable sorting for this column using ID */
   sortBy?: boolean;
 }

--- a/@stellar/design-system/src/components/Textarea/index.tsx
+++ b/@stellar/design-system/src/components/Textarea/index.tsx
@@ -15,17 +15,17 @@ export interface TextareaProps {
   /** Content of the textarea */
   children?: string;
   /** Label of the textarea */
-  label?: string | React.ReactNode;
+  label?: React.ReactNode;
   /** Adds suffix to the label */
-  labelSuffix?: string | React.ReactNode;
+  labelSuffix?: React.ReactNode;
   /** Note message of the textarea */
-  note?: string | React.ReactNode;
+  note?: React.ReactNode;
   /** Error message of the textarea */
-  error?: string | React.ReactNode;
+  error?: React.ReactNode;
   /** Success message of the input */
-  success?: string | React.ReactNode;
+  success?: React.ReactNode;
   /** Info text tooltip */
-  infoText?: string | React.ReactNode;
+  infoText?: React.ReactNode;
   /** Info text icon @defaultValue `<Icon.InfoCircle />` */
   infoTextIcon?: React.ReactNode;
   /** External link to open in new window */

--- a/@stellar/design-system/src/components/Typography/index.tsx
+++ b/@stellar/design-system/src/components/Typography/index.tsx
@@ -15,14 +15,13 @@ export interface DisplayProps {
   /** Display font weight @defaultValue `regular` */
   weight?: "bold" | "semi-bold" | "medium" | "regular";
   /** Display text */
-  children: string | React.ReactNode;
+  children: React.ReactNode;
 }
 
 interface DProps
-  extends
-    DisplayProps,
+  extends DisplayProps,
     React.HtmlHTMLAttributes<HTMLDivElement | HTMLSpanElement> {
-  children: string | React.ReactNode;
+  children: React.ReactNode;
 }
 
 /**
@@ -62,12 +61,13 @@ export interface HeadingProps {
   /** Heading font weight @defaultValue `regular` */
   weight?: "bold" | "semi-bold" | "medium" | "regular";
   /** Heading text */
-  children: string | React.ReactNode;
+  children: React.ReactNode;
 }
 
 interface HProps
-  extends HeadingProps, React.HtmlHTMLAttributes<HTMLHeadingElement> {
-  children: string | React.ReactNode;
+  extends HeadingProps,
+    React.HtmlHTMLAttributes<HTMLHeadingElement> {
+  children: React.ReactNode;
 }
 
 /**
@@ -107,16 +107,15 @@ export interface TextProps {
   /** Text font weight @defaultValue `regular` */
   weight?: "bold" | "semi-bold" | "medium" | "regular";
   /** Text content */
-  children: string | React.ReactNode;
+  children: React.ReactNode;
 }
 
 interface TProps
-  extends
-    TextProps,
+  extends TextProps,
     React.HtmlHTMLAttributes<
       HTMLParagraphElement | HTMLDivElement | HTMLSpanElement
     > {
-  children: string | React.ReactNode;
+  children: React.ReactNode;
 }
 
 /**
@@ -152,11 +151,11 @@ export interface CodeProps {
   /** Code size */
   size: "md" | "sm" | "xs";
   /** Code content */
-  children: string | React.ReactNode;
+  children: React.ReactNode;
 }
 
 interface CProps extends CodeProps, React.HtmlHTMLAttributes<HTMLElement> {
-  children: string | React.ReactNode;
+  children: React.ReactNode;
 }
 
 /**

--- a/@stellar/design-system/src/components/utils/FieldNote/index.tsx
+++ b/@stellar/design-system/src/components/utils/FieldNote/index.tsx
@@ -4,7 +4,7 @@ import "./styles.scss";
 interface FieldNoteProps {
   variant?: "note" | "error" | "success";
   size: "sm" | "md" | "lg";
-  children: string | React.ReactNode;
+  children: React.ReactNode;
 }
 
 export const FieldNote = ({


### PR DESCRIPTION
- removed unused 'secondary' ([figma](https://www.figma.com/design/d3QpogVCk3yqECAQs33CPU/SDS-3.0-Library?node-id=5342-4766&t=McDISEDKPNcpLmLj-0))
- 😱 `actionLink` prop to accept string 
- `title` prop to accept `ReactNode`
- Notification message to include `div` in place for `flexbox` and `column` direction to apply by default (some of lab's `<Notification/>` uses plain string and flexbox didn't get adopted
- Applied lilac color for primary for background

Found these bugs while updating the following PR: https://github.com/stellar/laboratory/pull/2123